### PR TITLE
Fix daylight progression across months

### DIFF
--- a/js/simulation.js
+++ b/js/simulation.js
@@ -351,7 +351,7 @@ export function dailyTurn(world) {
     }
     onNewMonth(world);
   }
-  world.daylight = computeDaylightByIndex((world.calendar.day - 1) + (world.calendar.month - 1) * DAYS_PER_YEAR);
+  world.daylight = computeDaylightByIndex((world.calendar.month - 1) * DAYS_PER_MONTH + (world.calendar.day - 1));
 
   if (world.store.wheat > 0) world.store.wheat = Math.max(0, world.store.wheat - DEMAND.household_wheat_bu_per_day);
 


### PR DESCRIPTION
## Summary
- correct the daily daylight index to advance sequentially across the 160-day calendar

## Testing
- node --input-type=module - <<'EOF'
import { computeDaylightByIndex } from './js/world.js';
import { DAYS_PER_MONTH } from './js/constants.js';

const samples = [
  { month: 1, day: 20 },
  { month: 2, day: 1 },
  { month: 4, day: 20 },
  { month: 5, day: 1 },
];

for (const { month, day } of samples) {
  const idx = (month - 1) * DAYS_PER_MONTH + (day - 1);
  const daylight = computeDaylightByIndex(idx);
  console.log(`M${month} D${day} -> idx ${idx} daylight ${daylight.dayLenHours.toFixed(3)}h sunrise ${daylight.sunrise} sunset ${daylight.sunset}`);
}
EOF

------
https://chatgpt.com/codex/tasks/task_e_68d76a0d60d4832ba08f85f9f88a15c2