### PR TITLE
Fix monthly task estimates and preserve task ID zero

### DIFF
--- a/js/persistence.js
+++ b/js/persistence.js
@@ -121,12 +121,12 @@ export function fromSnapshot(snap) {
   const queuedIds = new Set(world.tasks.month.queued.map(t => t.id));
   for (let i = 0; i < Math.min(slotCount, savedActiveWork.length); i++) {
     const id = savedActiveWork[i];
-    if (!id) continue;
+    if (id == null) continue;
     if (activeIds.has(id)) {
       world.farmer.activeWork[i] = id;
     }
   }
-  const assignedIds = new Set(world.farmer.activeWork.filter(Boolean));
+  const assignedIds = new Set(world.farmer.activeWork.filter(id => id != null));
   const stillActive = [];
   for (const task of world.tasks.month.active) {
     if (assignedIds.has(task.id)) {
@@ -139,7 +139,7 @@ export function fromSnapshot(snap) {
   }
   world.tasks.month.active = stillActive;
   const ensureQueued = (id) => {
-    if (!id || assignedIds.has(id) || queuedIds.has(id)) return;
+    if (id == null || assignedIds.has(id) || queuedIds.has(id)) return;
     const idx = world.tasks.month.overdue.findIndex(t => t.id === id);
     if (idx !== -1) {
       const [task] = world.tasks.month.overdue.splice(idx, 1);

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -135,7 +135,7 @@ function maybeToolBreak(world, task) {
 export function planDayMonthly(world) {
   world.tasks.month.queued.sort((a, b) => scoreTask(world, b) - scoreTask(world, a));
   for (let i = 0; i < CREW_SLOTS; i++) {
-    if (world.farmer.activeWork[i]) continue;
+    if (world.farmer.activeWork[i] != null) continue;
     let task;
     let guard = world.tasks.month.queued.length;
     let foundTask = false;
@@ -168,7 +168,7 @@ export function tickWorkMinute(world) {
   let needsTopUp = false;
   for (let s = 0; s < CREW_SLOTS; s++) {
     const id = world.farmer.activeWork[s];
-    if (!id) continue;
+    if (id == null) continue;
     const t = findTaskById(world, id);
     if (!t) {
       world.farmer.activeWork[s] = null;
@@ -189,7 +189,7 @@ export function tickWorkMinute(world) {
   if (!needsTopUp) return;
 
   for (let s = 0; s < CREW_SLOTS; s++) {
-    if (world.farmer.activeWork[s]) continue;
+    if (world.farmer.activeWork[s] != null) continue;
     let task;
     let foundAndAssigned = false;
     const pools = [world.tasks.month.overdue, world.tasks.month.queued];


### PR DESCRIPTION
## Summary
- guard farmer work slots and persistence logic against treating task ID 0 as empty
- keep active task IDs when restoring saves so queued work is not dropped on reload
- derive standalone estimates for non-parcel monthly jobs so they reflect their configured workloads

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d76f2d1c10832b91eda21a5c74274c