### PR TITLE
Fix farmer planning and cart task handling

### DIFF
--- a/js/render.js
+++ b/js/render.js
@@ -181,6 +181,28 @@ export function renderColored(world) {
       }
     }
   }
-  putStyled(buf, styleBuf, world.farmer.x - camX, world.farmer.y - camY, '@', SID.FARMER);
+  drawFarmer(buf, styleBuf, world, camX, camY);
+  debugHUD(buf, styleBuf, world);
   return { buf, styleBuf };
+}
+
+function drawFarmer(buf, styleBuf, world, camX, camY) {
+  const farmer = world.farmer || {};
+  const px = farmer.x - camX;
+  const py = farmer.y - camY;
+  if (px < 0 || px >= SCREEN_W || py < 0 || py >= SCREEN_H) return;
+  putStyled(buf, styleBuf, px, py, '@', SID.FARMER);
+  if (farmer.task) {
+    const labelX = Math.min(SCREEN_W - 1, Math.max(0, px + 1));
+    const labelY = Math.max(0, py - 1);
+    label(buf, styleBuf, labelX, labelY, farmer.task, SID.HUD_TEXT);
+  }
+}
+
+function debugHUD(buf, styleBuf, world) {
+  const minute = world.calendar.minute ?? 0;
+  const daylight = world.daylight || { workStart: 0, workEnd: 0 };
+  const slots = (world.farmer?.activeWork ?? []).map(id => id ?? '-').join(',');
+  const line = `m=${minute} ws=${daylight.workStart} we=${daylight.workEnd} slots=[${slots}] task=${world.farmer?.task ?? ''}`;
+  label(buf, styleBuf, 1, 0, line, SID.HUD_TEXT);
 }

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -26,7 +26,8 @@ import {
   endOfDayMonth,
   moistureToMud,
   processFarmerMinute,
-  syncFarmerToActiveParcel,
+  syncFarmerToActive,
+  hasActiveWork,
 } from './tasks.js';
 import { advisorExecute, reprioritiseByVPM, updateKPIs } from './advisor.js';
 import { attachPastureIfNeeded } from './world.js';
@@ -200,7 +201,7 @@ export function planDay(world) {
     advisorExecute(world);
   }
   planDayMonthly(world);
-  syncFarmerToActiveParcel(world);
+  syncFarmerToActive(world);
 }
 
 export function stepOneMinute(world) {
@@ -212,6 +213,8 @@ export function stepOneMinute(world) {
   if (minute >= daylight.workStart && minute <= daylight.workEnd) {
     tickWorkMinute(world);
   }
+
+  if (!hasActiveWork(world)) planDay(world);
 
   world.calendar.minute = (minute + 1);
   if (world.calendar.minute >= MINUTES_PER_DAY) {


### PR DESCRIPTION
## Summary
- call the daily planner when the work queue is empty or a new day starts so the farmer keeps moving to active work
- route CartToMarket jobs through the regular work loop with distance-based timing, gates, and visible travel queues
- tag parcels by proximity to the farmhouse and surface the farmer task/debug state in the renderer

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d8128843c8832b83f52ada43473aa7