### PR TITLE
Expand viewport to fill available space

### DIFF
--- a/style.css
+++ b/style.css
@@ -115,8 +115,8 @@ button:focus-visible {
   flex: 1;
   display: flex;
   align-items: stretch;
-  justify-content: center;
-  padding: 20px;
+  justify-content: flex-start;
+  padding: 0;
   min-height: 0;
   box-sizing: border-box;
 }
@@ -125,7 +125,9 @@ button:focus-visible {
   position: relative;
   flex: 1;
   display: flex;
-  max-width: 100%;
+  width: 100%;
+  height: 100%;
+  max-width: none;
   background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 12px;
@@ -135,9 +137,11 @@ button:focus-visible {
 #screen {
   flex: 1;
   margin: 0;
-  padding: 16px;
+  padding: 20px;
+  width: 100%;
+  height: 100%;
   white-space: pre;
-  overflow: hidden;
+  overflow: auto;
   min-height: 0;
   box-sizing: border-box;
 }


### PR DESCRIPTION
## Summary
- adjust the viewport layout so the farm display stretches with the available screen space
- allow the screen container to occupy the full width/height and scroll when needed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d87165930c832bbe543cec8efacdeb