### PR TITLE
Switch simulation to real-time flow and remove Advance Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ A Norfolk-style farm planner tuned for an eight-month, twenty-day calendar. The 
 
 ## Getting Started
 
-Open `index.html` in any modern browser. The HUD shows current month/day, simulation time, and labour usage. Use the **Advance Day** button to consume scheduled work and roll time forward; the planner panel updates as tasks complete and field phases change.
+Open `index.html` in any modern browser. The HUD shows current month/day, simulation time, and labour usage. Time now flows continuously according to the selected speed; use the slider or presets to adjust the pace and watch the planner update as work completes throughout the season.
 
 ## Roadmap
 

--- a/index.html
+++ b/index.html
@@ -22,7 +22,6 @@
       <div class="header-actions">
         <button id="follow-toggle" type="button" aria-pressed="true" title="Toggle following the farmer">Following Farmer</button>
         <button id="menu-toggle" type="button" aria-expanded="false" aria-controls="info-drawer" title="Open information panels">Open Menu</button>
-        <button id="advance-day" type="button" title="Advance to the next day">Advance Day</button>
       </div>
     </header>
     <div id="main">

--- a/style.css
+++ b/style.css
@@ -90,16 +90,6 @@ button:hover {
   background: rgba(148, 163, 184, 0.2);
 }
 
-#advance-day {
-  background: rgba(163, 190, 140, 0.2);
-  border-color: rgba(163, 190, 140, 0.6);
-  color: var(--accent);
-}
-
-#advance-day:hover {
-  background: rgba(163, 190, 140, 0.35);
-}
-
 button:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;


### PR DESCRIPTION
## Summary
- remove the Advance Day button and its styling from the UI and refresh the controls panel copy
- drive the simulation with a real-time loop tied to the speed controls, automatically processing daily work
- update the documentation to describe continuous time and the speed controls

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d879295a04832b9427e61069c3f45a