### PR TITLE
Switch overview screen to tile renderer

### DIFF
--- a/js/plan.js
+++ b/js/plan.js
@@ -11,16 +11,16 @@ import {
 
 export const MONTHLY_PLAN = {
   I: [
-    { op: 'plough+harrow', fields: ['barley_clover', 'beans_peas', 'A_oats'] },
+    { op: 'plough+harrow', fields: ['barley_clover', 'pulses', 'close_a'] },
     {
       op: 'sow',
       pairs: [
         ['barley_clover', 'barley+clover'],
-        ['beans_peas', 'beans/peas/vetch'],
-        ['A_oats', 'oats'],
+        ['pulses', 'beans/peas/vetch'],
+        ['close_a', 'oats'],
       ],
     },
-    { op: 'garden_plant', what: ['onions', 'cabbages', 'carrots'], parcel: 'homestead_garden' },
+    { op: 'garden_plant', what: ['onions', 'cabbages', 'carrots'], parcel: 'homestead' },
     { op: 'move_sheep', from: 'turnips', to: 'clover_hay' },
   ],
 };
@@ -45,7 +45,7 @@ function flattenJobs(world, planItem) {
       jobs.push(sow(field, crop));
     }
   } else if (planItem.op === 'garden_plant') {
-    jobs.push(gardenPlant(planItem.parcel ?? 'homestead_garden', planItem.what));
+    jobs.push(gardenPlant(planItem.parcel ?? 'homestead', planItem.what));
   } else if (planItem.op === 'move_sheep') {
     jobs.push(moveSheep(planItem.from, planItem.to));
   }

--- a/js/tasks.js
+++ b/js/tasks.js
@@ -159,9 +159,10 @@ export function cartToMarket() {
 }
 
 export function shouldGoToMarket(world) {
-  const lowOats = (world?.stores?.oats_bu ?? 0) < OATS_LOW_THRESHOLD;
-  const surplus = (world?.stores?.barley_bu ?? 0) > 280 || (world?.stores?.beans_bu ?? 0) > 140;
-  const parcels = [...(world?.fields ?? []), ...(world?.closes ?? [])];
+  const store = world?.store ?? {};
+  const lowOats = (store.oats ?? 0) < OATS_LOW_THRESHOLD;
+  const surplus = (store.barley ?? 0) > 280 || (store.pulses ?? 0) > 140;
+  const parcels = Array.isArray(world?.parcels) ? world.parcels : [];
   const pendingSeed = parcels.some((f) => f.phase === 'needs_seed');
   return Boolean(lowOats || surplus || pendingSeed);
 }


### PR DESCRIPTION
## Summary
- render the main screen using the colored tile buffer and span rows
- initialise the sim with the geometry-rich world from `makeWorld` and expose parcel metadata
- update planning and market helpers to operate on parcel-based world data

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8a4dafa34832b8ee96142adcfeeed