### PR TITLE
Introduce fixed-step simulation clock

### DIFF
--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -1,0 +1,33 @@
+import { assertCloseFieldWithinSteps, assertStepMatchesTick } from './config-pack.test.js';
+import {
+  testMovementEtaDeterminism,
+  testTaskProgressGatedByArrival,
+  testMonthRolloverBoundaries,
+} from './simulation-clock.test.js';
+
+const tests = [
+  ['config close field within steps', assertCloseFieldWithinSteps],
+  ['config travel step matches tick', assertStepMatchesTick],
+  ['movement eta determinism', testMovementEtaDeterminism],
+  ['task gating by location', testTaskProgressGatedByArrival],
+  ['month rollover boundaries', testMonthRolloverBoundaries],
+];
+
+let failed = false;
+
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    failed = true;
+    console.error(`✗ ${name}`);
+    console.error(error);
+  }
+}
+
+if (failed) {
+  process.exitCode = 1;
+} else {
+  console.log('All tests passed');
+}

--- a/js/tests/simulation-clock.test.js
+++ b/js/tests/simulation-clock.test.js
@@ -1,0 +1,102 @@
+import { strict as assert } from 'node:assert';
+import { createInitialWorld } from '../world.js';
+import { createEngineState, tick as runEngineTick } from '../engine.js';
+import { JOBS } from '../jobs.js';
+import { resetTime, advanceSimMinutes, getSimTime, SIM, MINUTES_PER_DAY, DAYS_PER_MONTH } from '../time.js';
+
+function setupEngine() {
+  resetTime();
+  const world = createInitialWorld();
+  const engine = createEngineState(world);
+  engine.world = world;
+  engine.stepCost = SIM.STEP_MIN;
+  if (engine.progress?.done instanceof Set) {
+    for (const job of JOBS) {
+      if (job?.id) engine.progress.done.add(job.id);
+    }
+  }
+  return { world, engine };
+}
+
+export function testMovementEtaDeterminism() {
+  const { world, engine } = setupEngine();
+  const start = { x: engine.farmer.pos.x, y: engine.farmer.pos.y };
+  const target = { x: start.x + 4, y: start.y + 3 };
+  const distance = Math.abs(target.x - start.x) + Math.abs(target.y - start.y);
+
+  engine.currentTask = {
+    definition: { id: 'test_move', kind: 'TestMove' },
+    runtime: { target, hours: 0, kind: 'TestMove' },
+    totalSimMin: 0,
+    remainingSimMin: SIM.STEP_MIN,
+    target,
+    startedAt: { year: world.calendar.year, month: world.calendar.month, day: world.calendar.day },
+  };
+
+  const path = [];
+  for (let i = 0; i < distance; i += 1) {
+    runEngineTick(engine, SIM.STEP_MIN);
+    path.push({ x: engine.farmer.pos.x, y: engine.farmer.pos.y });
+  }
+
+  assert.strictEqual(engine.farmer.pos.x, target.x);
+  assert.strictEqual(engine.farmer.pos.y, target.y);
+  assert.strictEqual(engine.labour.travelSimMin, distance * SIM.STEP_MIN);
+  for (let i = 1; i < path.length; i += 1) {
+    const prev = path[i - 1];
+    const curr = path[i];
+    const stepDist = Math.abs(curr.x - prev.x) + Math.abs(curr.y - prev.y);
+    assert.strictEqual(stepDist, 1);
+  }
+  const travelled = engine.labour.travelSimMin;
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(engine.farmer.pos.x, target.x);
+  assert.strictEqual(engine.farmer.pos.y, target.y);
+  assert.strictEqual(engine.labour.travelSimMin, travelled);
+}
+
+export function testTaskProgressGatedByArrival() {
+  const { world, engine } = setupEngine();
+  const start = { x: engine.farmer.pos.x, y: engine.farmer.pos.y };
+  const target = { x: start.x + 1, y: start.y + 1 };
+  const initialRemaining = SIM.STEP_MIN * 4;
+
+  engine.currentTask = {
+    definition: { id: 'test_work', kind: 'TestWork' },
+    runtime: { target, hours: initialRemaining / 60, kind: 'TestWork' },
+    totalSimMin: initialRemaining,
+    remainingSimMin: initialRemaining,
+    target,
+    startedAt: { year: world.calendar.year, month: world.calendar.month, day: world.calendar.day },
+  };
+
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(engine.currentTask.remainingSimMin, initialRemaining);
+  assert.strictEqual(engine.labour.workSimMin, 0);
+
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(engine.farmer.pos.x, target.x);
+  assert.strictEqual(engine.farmer.pos.y, target.y);
+  assert.strictEqual(engine.currentTask.remainingSimMin, initialRemaining);
+  assert.strictEqual(engine.labour.workSimMin, 0);
+
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(engine.currentTask.remainingSimMin, initialRemaining - SIM.STEP_MIN);
+  assert.strictEqual(engine.labour.workSimMin, SIM.STEP_MIN);
+}
+
+export function testMonthRolloverBoundaries() {
+  resetTime();
+  advanceSimMinutes(MINUTES_PER_DAY * DAYS_PER_MONTH - SIM.STEP_MIN);
+  let calendar = getSimTime();
+  assert.strictEqual(calendar.monthIndex, 0);
+  assert.strictEqual(calendar.day, DAYS_PER_MONTH);
+  assert.ok(Math.abs(calendar.minute - (MINUTES_PER_DAY - SIM.STEP_MIN)) < 1e-6);
+
+  advanceSimMinutes(SIM.STEP_MIN);
+  calendar = getSimTime();
+  assert.strictEqual(calendar.monthIndex, 1);
+  assert.strictEqual(calendar.day, 1);
+  assert.strictEqual(calendar.minute, 0);
+  assert.strictEqual(calendar.year, 1);
+}

--- a/js/time/SimulationClock.js
+++ b/js/time/SimulationClock.js
@@ -1,0 +1,87 @@
+export class SimulationClock {
+  constructor({ speedSimMinPerRealMin = 60, stepSimMin = 0.5 } = {}) {
+    this.speed = Math.max(0, Number.isFinite(speedSimMinPerRealMin) ? speedSimMinPerRealMin : 0);
+    this.step = Math.max(1e-6, Number.isFinite(stepSimMin) && stepSimMin > 0 ? stepSimMin : 0.5);
+    this.listeners = new Set();
+    this.running = false;
+    this._now = 0;
+    this._acc = 0;
+    this._last = 0;
+    this._loop = this._loop.bind(this);
+  }
+
+  onTick(fn) {
+    if (typeof fn !== 'function') return () => {};
+    this.listeners.add(fn);
+    return () => {
+      this.listeners.delete(fn);
+    };
+  }
+
+  setSpeed(value) {
+    const next = Number.isFinite(value) ? value : 0;
+    this.speed = Math.max(0, next);
+    if (this.speed <= 0) {
+      this._acc = 0;
+    }
+  }
+
+  nowSimMin() {
+    return this._now;
+  }
+
+  start() {
+    if (this.running) return;
+    this.running = true;
+    this._acc = 0;
+    this._last = this._nowTimestamp();
+    this._scheduleNext();
+  }
+
+  stop() {
+    this.running = false;
+  }
+
+  _nowTimestamp() {
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function') {
+      return performance.now();
+    }
+    if (typeof Date !== 'undefined') {
+      return Date.now();
+    }
+    return 0;
+  }
+
+  _scheduleNext() {
+    if (typeof requestAnimationFrame === 'function') {
+      requestAnimationFrame(this._loop);
+    } else {
+      setTimeout(() => this._loop(this._nowTimestamp()), 16);
+    }
+  }
+
+  _loop(timestamp) {
+    if (!this.running) return;
+    const current = Number.isFinite(timestamp) ? timestamp : this._nowTimestamp();
+    const dtMs = current - this._last;
+    this._last = current;
+
+    if (this.speed > 0) {
+      const msPerStep = (this.step * 60000) / this.speed;
+      if (msPerStep > 0 && Number.isFinite(msPerStep)) {
+        this._acc += Math.max(0, dtMs);
+        while (this._acc + 1e-9 >= msPerStep) {
+          this._now += this.step;
+          for (const fn of this.listeners) {
+            fn(this.step, this._now);
+          }
+          this._acc -= msPerStep;
+        }
+      }
+    }
+
+    if (this.running) {
+      this._scheduleNext();
+    }
+  }
+}

--- a/js/timeflow.js
+++ b/js/timeflow.js
@@ -2,18 +2,27 @@ import { CONFIG_PACK_V1 } from './config/pack_v1.js';
 
 export const SPEEDS = Object.freeze({ ...CONFIG_PACK_V1.time?.speedMultipliers });
 
-let current = 1.0;
+const DEFAULT_SIM_MIN_PER_REAL_MIN = CONFIG_PACK_V1.time?.simMinPerRealMin ?? 60;
+const DEFAULT_SPEED = DEFAULT_SIM_MIN_PER_REAL_MIN / 60;
 
-const SIM_MIN_PER_REAL_MS = (CONFIG_PACK_V1.time?.simMinPerRealMin ?? 0) / (CONFIG_PACK_V1.time?.realMsPerMinute ?? 1);
+let current = DEFAULT_SPEED;
+let boundClock = null;
+
+export function bindClock(clock) {
+  boundClock = clock || null;
+  if (boundClock) {
+    boundClock.setSpeed(current * 60);
+  }
+}
 
 export function setSpeed(value) {
-  current = Math.max(0, Number.isFinite(value) ? value : 0);
+  const next = Math.max(0, Number.isFinite(value) ? value : 0);
+  current = next;
+  if (boundClock) {
+    boundClock.setSpeed(current * 60);
+  }
 }
 
 export function getSpeed() {
   return current;
-}
-
-export function minutesToAdvance(dtMs) {
-  return dtMs * SIM_MIN_PER_REAL_MS * current;
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "farming_sim",
+  "version": "1.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "node js/tests/run.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add a SimulationClock implementation and wire the browser entry point to drive updates from fixed ticks
- derive calendar, daylight, and speed control from the unified clock-backed sim time
- add deterministic movement, task gating, and calendar rollover tests with a simple runner script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d962071a90832b8e56d234efa7b482