### PR TITLE
Prevent infinite scheduled task loops and externalize thresholds

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -146,6 +146,9 @@ export const CONFIG = {
   LIVESTOCK_SELL_VALUE: 100,
 };
 
+export const MAX_SCHEDULED_TASK_ATTEMPTS = 100;
+export const MID_MONTH_LABOUR_THRESHOLD = 0.35;
+
 export const WORK_MINUTES = {
   PlantRow: 25, HarvestRow: 45, TendRow: 10, IrrigateRow: 12, DrawWater: 15,
   PloughPlot_perAcre: 160,   HarrowPlot_perAcre: 60,   DrillPlot_perAcre: 45,

--- a/js/engine.js
+++ b/js/engine.js
@@ -5,7 +5,7 @@ import { instantiateJob, applyJobCompletion, simMinutesForHours } from './jobCat
 import { consume } from './labour.js';
 import { TASK_META } from './task_meta.js';
 import { applyResourceDeltas } from './resources.js';
-import { DAYS_PER_MONTH } from './constants.js';
+import { DAYS_PER_MONTH, MAX_SCHEDULED_TASK_ATTEMPTS } from './constants.js';
 
 const STEP_COST_DEFAULT = CONFIG_PACK_V1.labour.travelStepSimMin ?? 0.5;
 const MINUTES_PER_HOUR = CONFIG_PACK_V1.time.minutesPerHour ?? 60;
@@ -84,7 +84,7 @@ function recordTaskHistory(state, job) {
 }
 
 function beginScheduledTask(state) {
-  while (true) {
+  for (let attempts = 0; attempts < MAX_SCHEDULED_TASK_ATTEMPTS; attempts += 1) {
     const next = pickNextTask(state);
     if (!next) {
       state.currentTask = null;
@@ -121,6 +121,8 @@ function beginScheduledTask(state) {
     if (state.farmer) state.farmer.path = [];
     return state.currentTask;
   }
+  state.currentTask = null;
+  return null;
 }
 
 function normalizeTile(tile) {

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -16,6 +16,7 @@ import {
   MONTHS_PER_YEAR,
   seasonOfMonth,
   DAYS_PER_YEAR,
+  MID_MONTH_LABOUR_THRESHOLD,
 } from './constants.js';
 import { makeWorld } from './world.js';
 import {
@@ -185,7 +186,7 @@ function midMonthReprioritise(world) {
   if (world.calendar.day !== 10) return;
   const urgent = world.tasks.month.queued.filter(t => t.latestDay <= 14).length;
   const labourUsed = world.labour.usedMin / world.labour.monthBudgetMin;
-  if (urgent > 0 && labourUsed < 0.35) {
+  if (urgent > 0 && labourUsed < MID_MONTH_LABOUR_THRESHOLD) {
     world.tasks.month.queued = world.tasks.month.queued.filter(t => {
       if (['Repair', 'Prune', 'GardenSow'].includes(t.kind)) {
         t.priority = 0;


### PR DESCRIPTION
## Summary
- add a maximum attempt safeguard when selecting scheduled tasks to avoid infinite loops
- expose scheduling guard rails and mid-month labour threshold as shared constants
- consume the new threshold in the simulation reprioritisation logic for readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d98ca88620832bb20e845ecfd62d00