### PR TITLE
Increase simulation speed controls up to 10x

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
 
   <div id="speed-controls">
     <label for="speedSlider">Speed</label>
-    <input id="speedSlider" type="range" min="0" max="2.0" step="0.01" value="1.0" />
+    <input id="speedSlider" type="range" min="0" max="10.0" step="0.01" value="1.0" />
     <span id="speedLabel">1.00× min/s</span>
     <div>
       <button type="button" data-speed="0">Pause</button>
@@ -56,6 +56,7 @@
       <button type="button" data-speed="0.06">Slow</button>
       <button type="button" data-speed="0.12">Normal</button>
       <button type="button" data-speed="0.5">Fast</button>
+      <button type="button" data-speed="10.0">10× Speed</button>
     </div>
   </div>
 

--- a/js/ui/speed.js
+++ b/js/ui/speed.js
@@ -1,5 +1,14 @@
 import { setSpeed, getSpeed } from '../timeflow.js';
 
+const KEY_PRESETS = {
+  Digit1: 0.03,
+  Digit2: 0.06,
+  Digit3: 0.12,
+  Digit4: 0.5,
+  Digit5: 2.0,
+  Digit6: 10.0,
+};
+
 let slider;
 let label;
 let buttons;
@@ -54,15 +63,8 @@ export function initSpeedControls() {
       updateLabel();
       e.preventDefault();
     }
-    const presets = {
-      Digit1: 0.03,
-      Digit2: 0.06,
-      Digit3: 0.12,
-      Digit4: 0.5,
-      Digit5: 2.0,
-    };
-    if (presets[e.code] != null) {
-      const value = presets[e.code];
+    if (KEY_PRESETS[e.code] != null) {
+      const value = KEY_PRESETS[e.code];
       setSpeed(value);
       slider.value = String(value);
       slider.dataset.prev = String(value);


### PR DESCRIPTION
## Summary
- raise the speed slider limit to 10x and expose a dedicated quick-select button in the HUD
- add a keyboard shortcut preset for 10x playback so fast-forwarding works from the keyboard as well

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9994d2428832b944dcb431f66c385