### PR TITLE
Sync world farmer state with engine progress

### DIFF
--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -2,6 +2,7 @@ import { assertCloseFieldWithinSteps, assertStepMatchesTick } from './config-pac
 import {
   testMovementEtaDeterminism,
   testTaskProgressGatedByArrival,
+  testWorldFarmerStateSync,
   testMonthRolloverBoundaries,
 } from './simulation-clock.test.js';
 
@@ -10,6 +11,7 @@ const tests = [
   ['config travel step matches tick', assertStepMatchesTick],
   ['movement eta determinism', testMovementEtaDeterminism],
   ['task gating by location', testTaskProgressGatedByArrival],
+  ['world farmer mirrors engine state', testWorldFarmerStateSync],
   ['month rollover boundaries', testMonthRolloverBoundaries],
 ];
 

--- a/js/tests/simulation-clock.test.js
+++ b/js/tests/simulation-clock.test.js
@@ -85,6 +85,33 @@ export function testTaskProgressGatedByArrival() {
   assert.strictEqual(engine.labour.workSimMin, SIM.STEP_MIN);
 }
 
+export function testWorldFarmerStateSync() {
+  const { world, engine } = setupEngine();
+  const start = { x: engine.farmer.pos.x, y: engine.farmer.pos.y };
+  const target = { x: start.x + 2, y: start.y + 1 };
+
+  engine.currentTask = {
+    definition: { id: 'sync_task', kind: 'SyncWork' },
+    runtime: { target, hours: 0.5, kind: 'SyncWork' },
+    totalSimMin: SIM.STEP_MIN * 4,
+    remainingSimMin: SIM.STEP_MIN * 4,
+    target,
+    startedAt: { year: world.calendar.year, month: world.calendar.month, day: world.calendar.day },
+  };
+
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(world.farmer.x, engine.farmer.pos.x);
+  assert.strictEqual(world.farmer.y, engine.farmer.pos.y);
+  assert.strictEqual(world.farmer.task, 'SyncWork');
+  assert.ok(Array.isArray(world.farmer.activeWork));
+  assert.strictEqual(world.farmer.activeWork[0], 'sync_task');
+
+  engine.currentTask = null;
+  runEngineTick(engine, SIM.STEP_MIN);
+  assert.strictEqual(world.farmer.task, null);
+  assert.ok(world.farmer.activeWork.every((slot) => slot == null));
+}
+
 export function testMonthRolloverBoundaries() {
   resetTime();
   advanceSimMinutes(MINUTES_PER_DAY * DAYS_PER_MONTH - SIM.STEP_MIN);


### PR DESCRIPTION
## Summary
- mirror the farmer's engine position/task back onto the world object every tick so rendering can reflect movement
- reset and size the world farmer active-work slots consistently with crew capacity
- add a regression test that ensures the world farmer stays in sync with the engine and register it with the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d99abec298832bb5142f4e84e2028c