### PR TITLE
Fix livestock start syntax and improve crop/time handling

### DIFF
--- a/js/constants.js
+++ b/js/constants.js
@@ -221,4 +221,12 @@ export const CROPS = {
 
 export const ROTATION = [CROPS.TURNIPS, CROPS.BARLEY, CROPS.CLOVER, CROPS.WHEAT];
 
-export const LIVESTOCK_START = { horses:2, oxen:3, cows:2, bull:1, sheep:36, geese:16, poultry:24 };
+export const LIVESTOCK_START = {
+  horses: 2,
+  oxen: 3,
+  cows: 2,
+  bull: 1,
+  sheep: 36,
+  geese: 16,
+  poultry: 24
+};

--- a/js/time.js
+++ b/js/time.js
@@ -103,12 +103,8 @@ export function computeDaylightByIndex(index) {
 
 export function dayIndex(day = 1, month = 1) {
   const safeDay = Math.max(1, Math.min(DAYS_PER_MONTH, Math.floor(day)));
-  const numericMonth = Number.isFinite(month) ? Math.floor(month) : 1;
-  const zeroBasedMonth =
-    numericMonth >= 0 && numericMonth < MONTHS_PER_YEAR
-      ? clampMonthIndex(numericMonth)
-      : clampMonthIndex(numericMonth - 1);
-  return zeroBasedMonth * DAYS_PER_MONTH + (safeDay - 1);
+  const monthIdx = monthIndexFromValue(month);
+  return monthIdx * DAYS_PER_MONTH + (safeDay - 1);
 }
 
 export const SIM = Object.freeze({

--- a/js/world.js
+++ b/js/world.js
@@ -406,7 +406,8 @@ function createParcelFromTemplate(template, index) {
   const rowCount = Math.max(0, Math.floor(rowsRequested));
   const rows = [];
   const initialCropValue = template.initialCrop || template.initialCropKey || null;
-  const cropTemplate = typeof initialCropValue === 'string' ? CROPS[initialCropValue] : initialCropValue;
+  const cropTemplate =
+    typeof initialCropValue === 'string' ? (CROPS[initialCropValue] ?? null) : initialCropValue;
   for (let i = 0; i < rowCount; i++) {
     const crop = cropTemplate || null;
     rows.push({


### PR DESCRIPTION
## Summary
- format the LIVESTOCK_START constants without a trailing comma for better compatibility
- guard parcel crop initialization against non-string template keys
- simplify dayIndex month handling by reusing monthIndexFromValue

## Testing
- No tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a878f9ec832b90d0af6b0f76d847