### PR TITLE
Respect sell threshold when scheduling market jobs

### DIFF
--- a/js/jobs.js
+++ b/js/jobs.js
@@ -226,6 +226,7 @@ export const JOBS = [
     priority: 20,
     cooldownMin: MARKET_COOLDOWN,
     sellThreshold: CONFIG_PACK_V1.rules.sellTurnipThreshold ?? CART_CAPACITY,
+    sellResourceKey: 'turnips',
   },
 ];
 

--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -62,8 +62,9 @@ export function isEligible(state, job) {
     }
   }
   if (!canFulfillResources(state?.world, job.requiresResources)) return false;
-  if (typeof job.sellThreshold === 'number' && job.sellThreshold > 0) {
-    const stock = readResource(state?.world, 'turnips');
+  if (Number.isFinite(job.sellThreshold) && job.sellThreshold > 0) {
+    const resourceKey = job.sellResourceKey ?? 'turnips';
+    const stock = readResource(state?.world, resourceKey);
     if (stock < job.sellThreshold) return false;
   }
   if (state?.taskCooldowns instanceof Map) {


### PR DESCRIPTION
## Summary
- ensure the scheduler checks a job's sell threshold before selecting it
- allow jobs to specify which resource their threshold applies to and set it for market trips

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9ab91c82c832bab1dbced1259064d