### PR TITLE
Refactor parcel center helper usage and pasture regrowth constant

### DIFF
--- a/js/jobCatalog.js
+++ b/js/jobCatalog.js
@@ -1,5 +1,5 @@
 import { CONFIG_PACK_V1 } from './config/pack_v1.js';
-import { findField, recordJobCompletion } from './world.js';
+import { findField, recordJobCompletion, parcelCenter } from './world.js';
 import {
   RATES,
   plough,
@@ -16,13 +16,6 @@ function hoursFor(acres, perHour) {
   if (!Number.isFinite(acres) || acres <= 0) return 0;
   if (!Number.isFinite(perHour) || perHour <= 0) return 0;
   return acres / perHour;
-}
-
-function parcelCenter(parcel) {
-  if (!parcel) return { x: 0, y: 0 };
-  const x = Math.round((parcel.x ?? 0) + (parcel.w ?? 0) / 2);
-  const y = Math.round((parcel.y ?? 0) + (parcel.h ?? 0) / 2);
-  return { x, y };
 }
 
 function gardenCenter(world) {

--- a/js/simulation.js
+++ b/js/simulation.js
@@ -40,6 +40,8 @@ import { generateWeatherToday, dailyWeatherEvents } from './weather.js';
 export { processFarmerHalfStep } from './tasks.js';
 import { assertNoWorkOutsideWindow } from './tests/invariants.js';
 
+const PASTURE_REGROWTH_RATE = PASTURE.REGROW_T_PER_ACRE_PER_DAY;
+
 function chooseFlex(world, option) {
   world.flexChoice = option;
   const key = 'flex';
@@ -236,7 +238,7 @@ export function pastureRegrow(world) {
     if (!p.pasture) continue;
     const canRegrow = (p.key === 'clover_hay') || (p.status.cropNote?.includes('aftermath'));
     if (!canRegrow) continue;
-    const add = (m >= 1 && m <= 4) ? (PASTURE.REGROW_T_PER_ACRE_PER_DAY * p.acres) : 0;
+    const add = (m >= 1 && m <= 4) ? (PASTURE_REGROWTH_RATE * p.acres) : 0;
     const cap = p.acres * PASTURE.MAX_BIOMASS_T_PER_ACRE;
     p.pasture.biomass_t = Math.min(cap, p.pasture.biomass_t + add);
     p.pasture.grazedToday_t = 0;


### PR DESCRIPTION
## Summary
- reuse the shared `parcelCenter` helper from `world.js` when instantiating jobs to remove duplication
- introduce a named pasture regrowth rate constant for clarity inside the simulation logic

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9acc719d0832ba9e8f0178479e171