### PR TITLE
Add byre and coppice to estate rendering and navigation

### DIFF
--- a/js/config/pack_v1.js
+++ b/js/config/pack_v1.js
@@ -73,7 +73,7 @@ export const CONFIG_PACK_V1 = Object.freeze({
   estate: {
     farmhouse: { x: 23, y: 14 },
     market: { x: 8, y: 8 },
-    byre: { x: 30, y: 14 },
+    byre: { x: 30, y: 14, w: 8, h: 5 },
     parcels: [
       {
         key: 'close_1',
@@ -201,6 +201,18 @@ export const CONFIG_PACK_V1 = Object.freeze({
         y: 36,
         w: 12,
         h: 8,
+        rows: 0,
+      },
+      {
+        key: 'coppice',
+        name: 'Coppice',
+        acres: 2,
+        kind: 'coppice',
+        status: { cropNote: 'Woodland', stubble: false, tilth: 0 },
+        x: 10,
+        y: 10,
+        w: 12,
+        h: 12,
         rows: 0,
       },
     ],

--- a/js/constants.js
+++ b/js/constants.js
@@ -131,6 +131,7 @@ export const CONFIG = {
   SCREEN: { W: 100, H: 30 },
   WORLD:  { W: 210, H: 100 },
   HOUSE: { x: 15, y: 10, w: 16, h: 8 },
+  BYRE: { x: 30, y: 14, w: 8, h: 5 },
   WELL: { x: 35, y: 12 },
   FARMER_SPEED: 2,
   SPEED_LEVELS: [1000, 600, 300, 150, 75],
@@ -145,6 +146,9 @@ export const CONFIG = {
   LIVESTOCK_BUY_COST: 150,
   LIVESTOCK_SELL_VALUE: 100,
 };
+
+export const HOUSE = Object.freeze({ ...CONFIG.HOUSE });
+export const BYRE = Object.freeze({ ...CONFIG.BYRE });
 
 export const MAX_SCHEDULED_TASK_ATTEMPTS = 100;
 export const MID_MONTH_LABOUR_THRESHOLD = 0.35;
@@ -177,6 +181,7 @@ export const SID = {
   P_S1: 70, P_S2: 71, P_S3: 72, P_S4: 73, P_S5: 74,
   F_S1: 80, F_S2: 81, F_S3: 82, F_S4: 83, F_S5: 84,
   FARMER: 90, HOUSE_WALL: 91, DOOR: 92, WELL_WATER: 93, BORDER: 94, WELL_TEXT: 95, WOOD_FLOOR: 96,
+  BYRE_FLOOR: 97, BYRE_LABEL: 98, COPPICE_TREE: 99,
   HUD_TEXT: 100, W_RAIN: 101, W_STORM: 102, W_HOT: 103, W_SNOW: 104,
   BAR_LOW: 110, BAR_MID: 111, BAR_HIGH: 112, N_LOW: 113, N_MID: 114, N_HIGH: 115,
   MIXED_LABEL: 200,

--- a/js/pathfinding.js
+++ b/js/pathfinding.js
@@ -1,4 +1,4 @@
-import { CONFIG } from './constants.js';
+import { CONFIG, HOUSE, BYRE } from './constants.js';
 
 let Pathfinding = null;
 
@@ -71,9 +71,14 @@ export function createGrid(world) {
     applyWalkableRect(grid, parcel, true, worldWidth, worldHeight);
   }
 
-  const houseRect = CONFIG.HOUSE ?? null;
+  const houseRect = HOUSE ?? CONFIG.HOUSE ?? null;
   if (houseRect) {
     applyWalkableRect(grid, houseRect, false, worldWidth, worldHeight);
+  }
+
+  const byreRect = BYRE ?? CONFIG.BYRE ?? null;
+  if (byreRect) {
+    applyWalkableRect(grid, byreRect, false, worldWidth, worldHeight);
   }
 
   const fences = Array.isArray(world?.fences) ? world.fences : [];

--- a/js/render.js
+++ b/js/render.js
@@ -1,5 +1,5 @@
 import { clamp, lerp, hash01, isToday, CAMERA_LERP } from './utils.js';
-import { SCREEN_W, SCREEN_H, HOUSE, WELL } from './world.js';
+import { SCREEN_W, SCREEN_H, HOUSE, WELL, BYRE } from './world.js';
 import { SID, SID_BY_CROP, CROP_GLYPHS, GRASS_GLYPHS, CONFIG, seasonOfMonth } from './constants.js';
 import { rowBand } from './world.js';
 
@@ -122,6 +122,17 @@ export function renderColored(world, debugState = {}) {
     label(buf, styleBuf, houseSX + 1, houseSY + 1, 'Bed', SID.HOUSE_WALL);
     label(buf, styleBuf, houseSX + 8, houseSY + 1, 'Living', SID.HOUSE_WALL);
   }
+  const byreSX = BYRE.x - camX;
+  const byreSY = BYRE.y - camY;
+  if (byreSX + BYRE.w >= 0 && byreSX <= SCREEN_W && byreSY + BYRE.h >= 0 && byreSY <= SCREEN_H) {
+    for (let y = byreSY; y < byreSY + BYRE.h; y++) {
+      for (let x = byreSX; x < byreSX + BYRE.w; x++) {
+        putStyled(buf, styleBuf, x, y, '#', SID.BYRE_FLOOR);
+      }
+    }
+    label(buf, styleBuf, byreSX + 1, byreSY + Math.floor(BYRE.h / 2), 'BYRE', SID.BYRE_LABEL);
+  }
+
   const wellSX = WELL.x - camX;
   const wellSY = WELL.y - camY;
   if (wellSX + 4 >= 0 && wellSX - 3 <= SCREEN_W) {
@@ -146,6 +157,19 @@ export function renderColored(world, debugState = {}) {
     putStyled(buf, styleBuf, pSX, pSY + p.h - 1, '+', SID.BORDER);
     putStyled(buf, styleBuf, pSX + p.w - 1, pSY + p.h - 1, '+', SID.BORDER);
     label(buf, styleBuf, pSX + 2, pSY, pLabel, SID.MIXED_LABEL);
+    if (p.kind === 'coppice') {
+      const startY = Math.max(p.y + 1, camY);
+      const endY = Math.min(p.y + p.h - 1, camY + SCREEN_H);
+      const startX = Math.max(p.x + 1, camX);
+      const endX = Math.min(p.x + p.w - 1, camX + SCREEN_W);
+      for (let y = startY; y < endY; y++) {
+        for (let x = startX; x < endX; x++) {
+          const treeGlyph = hash01(x, y, world.seed) < 0.2 ? 'T' : 't';
+          putStyled(buf, styleBuf, x - camX, y - camY, treeGlyph, SID.COPPICE_TREE);
+        }
+      }
+    }
+
     if (p.rows.length > 0) {
       for (let r = 0; r < p.rows.length; r++) {
         const row = p.rows[r];

--- a/js/world.js
+++ b/js/world.js
@@ -18,6 +18,7 @@ import { createGrid } from './pathfinding.js';
 export const SCREEN_W = CONFIG.SCREEN.W;
 export const SCREEN_H = CONFIG.SCREEN.H;
 export const HOUSE = Object.freeze({ ...CONFIG.HOUSE });
+export const BYRE = Object.freeze({ ...CONFIG_PACK_V1.estate.byre });
 export const WELL = Object.freeze({ ...CONFIG.WELL });
 
 function freezeDeep(value) {

--- a/style.css
+++ b/style.css
@@ -393,6 +393,9 @@ body.hc {
     .hc .s80 { color:#22dd3c } .hc .s81 { color:#32e04a } .hc .s82 { color:#40e858 } .hc .s83 { color:#4af062 } .hc .s84 { color:#55f86f }
     .hc .s90 { color:#000000 } .hc .s91 { color:#555555 } .hc .s92 { color:#C1842C } .hc .s93 { color:#007BFF } .hc .s94 { color:#777777 } .hc .s95 { color:#666666 }
     .hc .s96 { color:#a56a42 }
+    .hc .s97 { color:#8b5a2b }
+    .hc .s98 { color:#1a1a1a }
+    .hc .s99 { color:#2f6b2f }
     .hc .s100 { color:#222222 } .hc .s101 { color:#007BFF } .hc .s102 { color:#4A56E2 } .hc .s103 { color:#E59400 } .hc .s104 { color:#9DB2BF }
     .hc .s110 { color:#D92626 } .hc .s111 { color:#D9A000 } .hc .s112 { color:#3D9952 }
     .hc .s200 { color:#666666 }
@@ -407,7 +410,7 @@ body.hc {
     .s60 { color:#6BAF4E } .s61 { color:#7FBF3F } .s62 { color:#9BC94A } .s63 { color:#B5CF4A } .s64 { color:#D8C05A }
     .s70 { color:#39B54A } .s71 { color:#49C65A } .s72 { color:#5BD66C } .s73 { color:#5BD66C } .s74 { color:#5BD66C; font-weight: bold; }
     .s80 { color:#55B46B } .s81 { color:#61BC76 } .s82 { color:#6CC482 } .s83 { color:#76CC8C } .s84 { color:#7ED08F }
-    .s90 { color:#E6EDF3; font-weight:700 } .s91 { color:#C7D0D9 } .s92 { color:#E9B96E } .s93 { color:#4DA3FF } .s94 { color:#94A3B8 } .s95 { color:#C0C7D1 } .s96 { color:#654321 }
+    .s90 { color:#E6EDF3; font-weight:700 } .s91 { color:#C7D0D9 } .s92 { color:#E9B96E } .s93 { color:#4DA3FF } .s94 { color:#94A3B8 } .s95 { color:#C0C7D1 } .s96 { color:#654321 } .s97 { color:#8B6F47 } .s98 { color:#F5E6C5 } .s99 { color:#3F7F3F }
     .s100 { color:#CBD5E1 } .s101 { color:#73B7FF } .s102 { color:#9AA9FF } .s103 { color:#FFB15E } .s104 { color:#DDE6F2 }
     .s110 { color:#C73D3D } .s111 { color:#E1B74F } .s112 { color:#66C07A } .s113 { color:#C050E8 } .s114 { color:#D58FEF } .s115 { color:#B4E57E }
     .s200 { color:#94A3B8 }


### PR DESCRIPTION
## Summary
- extend the pack v1 configuration with the byre footprint and a new coppice parcel
- expose BYRE constants and styles so the structure can be rendered with bespoke glyphs
- render the byre and coppice in the world view and exclude the byre from pathfinding routes

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d9c2ca22ec832bb3cbcfcd72538c15