### PR TITLE
Align market trip scheduler with guard rejection logic

### DIFF
--- a/js/tests/market.test.js
+++ b/js/tests/market.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import { needsMarketTrip } from '../market.js';
+import { canScheduleMarketTrip } from '../jobs/market_trip.js';
 import { MINUTES_PER_DAY } from '../time.js';
 import { DAYS_PER_MONTH } from '../constants.js';
 
@@ -35,4 +36,40 @@ test('needsMarketTrip respects cooldown across roman numeral months', () => {
   );
   assert.ok(Array.isArray(result.manifestOps) && result.manifestOps.length > 0, 'Expected manifestOps to contain operations');
   assert.equal(result.simulation?.ok, true);
+});
+
+function makeWorldForLowValueManifest() {
+  return {
+    calendar: { month: 'I', monthIndex: 0, day: 1, minute: 9 * 60 },
+    store: {
+      hay: 6,
+      wheat: 120,
+      barley: 120,
+      oats: 120,
+      pulses: 120,
+      seed: { wheat: 12, barley: 12, oats: 12, pulses: 12 },
+    },
+    finance: { loanDueWithinHours: () => false, cash: 100 },
+    market: {
+      lastTripAt: -Infinity,
+      cooldownMin: 0,
+    },
+    cash: 100,
+  };
+}
+
+test('canScheduleMarketTrip mirrors needsMarketTrip rejection for low-value manifests', () => {
+  const request = { buy: [{ item: 'hay_t', qty: 1, reason: 'top up hay' }] };
+  const needsWorld = makeWorldForLowValueManifest();
+  const scheduleWorld = makeWorldForLowValueManifest();
+  const needs = needsMarketTrip(needsWorld, request);
+  assert.equal(needs.ok, false, 'needsMarketTrip should reject the low-value manifest');
+  const gate = canScheduleMarketTrip(scheduleWorld, request);
+  assert.equal(gate.ok, false, 'scheduler should refuse the same manifest');
+  assert.ok(gate.reason.includes('value'), 'expected scheduler to explain low manifest value');
+  assert.deepEqual(
+    gate.summary.buy.map((line) => ({ item: line.item, qty: line.qty })),
+    needs.manifest.buy.map((line) => ({ item: line.item, qty: line.qty })),
+    'scheduler summary should mirror the rejected manifest lines',
+  );
 });


### PR DESCRIPTION
## Summary
- call `needsMarketTrip` from the market trip scheduler to guard manifest execution and retain attempted manifest details on failure
- ensure failed scheduling records a clear reason such as low-value manifests so the UI can surface the result
- extend market tests with a low-value manifest scenario to keep the guard and scheduler logic aligned

## Testing
- npm test *(fails: Missing farmhouse or oats_close parcel in config pack)*

------
https://chatgpt.com/codex/tasks/task_e_68dcc8c309a0832bb7afab51d49df815