### PR TITLE
Handle one-based month indices when setting sim time

### DIFF
--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -4,6 +4,7 @@ import {
   testTaskProgressGatedByArrival,
   testWorldFarmerStateSync,
   testMonthRolloverBoundaries,
+  testOneBasedMonthIndex,
 } from './simulation-clock.test.js';
 
 const tests = [
@@ -13,6 +14,7 @@ const tests = [
   ['task gating by location', testTaskProgressGatedByArrival],
   ['world farmer mirrors engine state', testWorldFarmerStateSync],
   ['month rollover boundaries', testMonthRolloverBoundaries],
+  ['one-based month index preserves first month', testOneBasedMonthIndex],
 ];
 
 let failed = false;

--- a/js/tests/simulation-clock.test.js
+++ b/js/tests/simulation-clock.test.js
@@ -2,7 +2,16 @@ import { strict as assert } from 'node:assert';
 import { createInitialWorld } from '../world.js';
 import { createEngineState, tick as runEngineTick } from '../engine.js';
 import { JOBS } from '../jobs.js';
-import { resetTime, advanceSimMinutes, getSimTime, SIM, MINUTES_PER_DAY, DAYS_PER_MONTH } from '../time.js';
+import {
+  resetTime,
+  advanceSimMinutes,
+  getSimTime,
+  setSimTime,
+  SIM,
+  MINUTES_PER_DAY,
+  DAYS_PER_MONTH,
+  CALENDAR,
+} from '../time.js';
 
 function setupEngine() {
   resetTime();
@@ -126,4 +135,12 @@ export function testMonthRolloverBoundaries() {
   assert.strictEqual(calendar.day, 1);
   assert.strictEqual(calendar.minute, 0);
   assert.strictEqual(calendar.year, 1);
+}
+
+export function testOneBasedMonthIndex() {
+  resetTime();
+  setSimTime({ monthIndex: 1 });
+  const calendar = getSimTime();
+  assert.strictEqual(calendar.monthIndex, 0);
+  assert.strictEqual(calendar.month, CALENDAR.MONTHS[0]);
 }

--- a/js/time.js
+++ b/js/time.js
@@ -135,8 +135,8 @@ export function resetTime() {
 function monthIndexFromValue(value) {
   if (Number.isFinite(value)) {
     const idx = Math.floor(value);
-    if (idx >= 0 && idx < MONTHS_PER_YEAR) return idx;
     if (idx >= 1 && idx <= MONTHS_PER_YEAR) return clampMonthIndex(idx - 1);
+    if (idx >= 0 && idx < MONTHS_PER_YEAR) return idx;
   }
   if (typeof value === 'string') {
     const idx = CALENDAR.MONTHS.indexOf(value);


### PR DESCRIPTION
## Summary
- treat numeric monthIndex values in the 1-based range as calendar months before applying zero-based handling
- extend the simulation clock tests to cover the one-based monthIndex behaviour
- register the new regression test with the test runner

## Testing
- npm test *(fails: Missing farmhouse or oats_close parcel in config pack)*

------
https://chatgpt.com/codex/tasks/task_e_68dcff684e4c832ba8341bc68b3dc41d