### PR TITLE
Fix calendar rollover to maintain month labels

### DIFF
--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -7,6 +7,7 @@ import {
   testOneBasedMonthIndex,
 } from './simulation-clock.test.js';
 import { testSeasonOfMonthAcceptsRomanNumerals } from './constants.test.js';
+import { testDailyTurnMonthRollover } from './simulation-date.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -15,6 +16,7 @@ const tests = [
   ['task gating by location', testTaskProgressGatedByArrival],
   ['world farmer mirrors engine state', testWorldFarmerStateSync],
   ['month rollover boundaries', testMonthRolloverBoundaries],
+  ['daily turn month rollover preserves labels', testDailyTurnMonthRollover],
   ['one-based month index preserves first month', testOneBasedMonthIndex],
   ['season helper accepts roman numerals', testSeasonOfMonthAcceptsRomanNumerals],
 ];

--- a/js/tests/simulation-date.test.js
+++ b/js/tests/simulation-date.test.js
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict';
+
+import { createInitialWorld } from '../world.js';
+import { dailyTurn } from '../simulation.js';
+import { DAYS_PER_MONTH, MONTH_NAMES } from '../constants.js';
+
+export function testDailyTurnMonthRollover() {
+  const world = createInitialWorld();
+
+  world.calendar.month = MONTH_NAMES[MONTH_NAMES.length - 1];
+  world.calendar.monthIndex = MONTH_NAMES.length - 1;
+  world.calendar.day = DAYS_PER_MONTH;
+  world.calendar.year = 3;
+  world.flexChoice = 'OATS';
+
+  dailyTurn(world);
+
+  assert.equal(world.calendar.day, 1, 'day should reset at month boundary');
+  assert.equal(world.calendar.monthIndex, 0, 'monthIndex should wrap to zero');
+  assert.equal(world.calendar.month, MONTH_NAMES[0], 'month label should match wrapped index');
+  assert.equal(world.calendar.year, 4, 'year should increment when month wraps');
+  assert.equal(world.daylight.month, MONTH_NAMES[0], 'daylight schedule should align with month label');
+}

--- a/js/weather.js
+++ b/js/weather.js
@@ -1,10 +1,10 @@
-import { WX_BASE } from './constants.js';
+import { WX_BASE, normalizeMonth } from './constants.js';
 import { randomNormal } from './utils.js';
 
 export function generateWeatherToday(world) {
-  const m = world.calendar.month;
+  const m = normalizeMonth(world.calendar.month);
   const rng = world.rng;
-  const base = WX_BASE[m];
+  const base = WX_BASE[m] || WX_BASE[1];
   const temp = base.tMean + 3.0 * randomNormal(rng);
   const wetChance = 0.45 + (base.rainMean - 2.0) * 0.06;
   const rain = (rng() < wetChance) ? Math.max(0, base.rainMean + 5 * randomNormal(rng)) : 0;
@@ -19,7 +19,7 @@ export function generateWeatherToday(world) {
 
 export function dailyWeatherEvents(world) {
   const w = world.weather;
-  const m = world.calendar.month;
+  const m = normalizeMonth(world.calendar.month);
   if (w.frostTonight) {
     const g = world.parcels[world.parcelByKey.homestead];
     g.status.frost = (g.status.frost || 0) + 1;


### PR DESCRIPTION
## Summary
- normalize month advancement so calendar monthIndex and roman labels stay in sync when rolling over
- update weather and soil systems to derive climate data from normalized month values
- add a simulation regression test for daily month rollover and wire it into the test harness

## Testing
- npm test *(fails: config close field within steps – missing oats_close parcel in config pack)*

------
https://chatgpt.com/codex/tasks/task_e_68dd05b76680832b8b627d9a8df04fcb