### PR TITLE
Centralize plant configuration in JSON

### DIFF
--- a/data/plants.json
+++ b/data/plants.json
@@ -1,0 +1,290 @@
+{
+  "rotation": ["TURNIPS", "BARLEY", "CLOVER", "WHEAT"],
+  "plants": [
+    {
+      "id": "TURNIPS",
+      "key": "T",
+      "name": "Turnips",
+      "category": "arable",
+      "type": "root",
+      "baseDays": 80,
+      "baseYield": 60,
+      "nitrogenUse": -0.1,
+      "glyphs": [".", "`", ",", "v", "w", "W"],
+      "stageSpriteIds": [11, 20, 21, 22, 23, 24],
+      "rotation": true,
+      "primaryYield": {
+        "storeKey": "turnips",
+        "marketKey": null,
+        "unit": "bu",
+        "startingQuantity": 50
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 0.2 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "aliases": ["turnips"],
+      "processing": { "winnow": false }
+    },
+    {
+      "id": "BARLEY",
+      "key": "B",
+      "name": "Barley",
+      "category": "arable",
+      "type": "grain",
+      "baseDays": 85,
+      "baseYield": 70,
+      "nitrogenUse": -0.12,
+      "glyphs": [".", ",", ";", "t", "Y", "H"],
+      "stageSpriteIds": [11, 30, 31, 32, 33, 34],
+      "rotation": true,
+      "primaryYield": {
+        "storeKey": "barley",
+        "marketKey": "barley_bu",
+        "unit": "bu",
+        "startingQuantity": 250
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 2 },
+        "inventoryKey": "barley",
+        "resourceKey": "seed_barley",
+        "marketItem": "seed_barley_bu",
+        "startingQuantity": 12
+      },
+      "sheaf": { "key": "B", "strawPerBushel": 1 },
+      "aliases": ["barley", "barley+clover"],
+      "processing": { "winnow": true }
+    },
+    {
+      "id": "CLOVER",
+      "key": "C",
+      "name": "Clover",
+      "category": "arable",
+      "type": "legume",
+      "baseDays": 70,
+      "baseYield": 25,
+      "nitrogenUse": 0.18,
+      "glyphs": [".", ",", "\"", "*", "c", "C"],
+      "stageSpriteIds": [11, 40, 41, 42, 43, 44],
+      "rotation": true,
+      "primaryYield": {
+        "storeKey": "hay",
+        "marketKey": "hay_t",
+        "unit": "t",
+        "startingQuantity": 12
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 0 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "salvage": { "storeKey": "hay", "multiplier": 0.8 },
+      "aliases": ["clover", "clover_hay"],
+      "processing": { "winnow": false }
+    },
+    {
+      "id": "WHEAT",
+      "key": "W",
+      "name": "Wheat",
+      "category": "arable",
+      "type": "grain",
+      "baseDays": 95,
+      "baseYield": 80,
+      "nitrogenUse": -0.14,
+      "glyphs": [".", ",", ";", "i", "I", "W"],
+      "stageSpriteIds": [11, 50, 51, 52, 53, 54],
+      "rotation": true,
+      "primaryYield": {
+        "storeKey": "wheat",
+        "marketKey": "wheat_bu",
+        "unit": "bu",
+        "startingQuantity": 180
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 2 },
+        "inventoryKey": "wheat",
+        "resourceKey": "seed_wheat",
+        "marketItem": "seed_wheat_bu",
+        "startingQuantity": 14
+      },
+      "sheaf": { "key": "W", "strawPerBushel": 1.2 },
+      "aliases": ["wheat", "winter_wheat"],
+      "processing": { "winnow": true }
+    },
+    {
+      "id": "OATS",
+      "key": "O",
+      "name": "Oats",
+      "category": "arable",
+      "type": "grain",
+      "baseDays": 85,
+      "baseYield": 65,
+      "nitrogenUse": -0.12,
+      "glyphs": [".", ",", ";", "t", "T", "Y"],
+      "stageSpriteIds": [11, 60, 61, 62, 63, 64],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": "oats",
+        "marketKey": "oats_bu",
+        "unit": "bu",
+        "startingQuantity": 60
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 2 },
+        "inventoryKey": "oats",
+        "resourceKey": "seed_oats",
+        "marketItem": "seed_oats_bu",
+        "startingQuantity": 10
+      },
+      "sheaf": { "key": "O", "strawPerBushel": 1.1 },
+      "aliases": ["oats", "oats_close"],
+      "processing": { "winnow": true }
+    },
+    {
+      "id": "PULSES",
+      "key": "P",
+      "name": "Beans/Peas/Vetch",
+      "category": "arable",
+      "type": "pulse",
+      "baseDays": 90,
+      "baseYield": 45,
+      "nitrogenUse": 0.06,
+      "glyphs": [".", "o", "d", "b", "8", "&"],
+      "stageSpriteIds": [11, 70, 71, 72, 73, 74],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": "pulses",
+        "marketKey": "pulses_bu",
+        "unit": "bu",
+        "startingQuantity": 120
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 1.5 },
+        "inventoryKey": "pulses",
+        "resourceKey": "seed_pulses",
+        "marketItem": "seed_pulses_bu",
+        "startingQuantity": 8
+      },
+      "sheaf": { "key": "P", "strawPerBushel": 0.6 },
+      "aliases": ["pulses", "beans_peas", "beans/peas/vetch"],
+      "processing": { "winnow": true }
+    },
+    {
+      "id": "FLAX",
+      "key": "F",
+      "name": "Flax/Hemp",
+      "category": "arable",
+      "type": "fiber",
+      "baseDays": 100,
+      "baseYield": 30,
+      "nitrogenUse": -0.1,
+      "glyphs": [".", "|", "i", "t", "T", "#"],
+      "stageSpriteIds": [11, 80, 81, 82, 83, 84],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": "flax",
+        "marketKey": null,
+        "unit": "bundle",
+        "startingQuantity": 0
+      },
+      "seed": {
+        "rate": { "unit": "bu_per_acre", "value": 0 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "aliases": ["flax"],
+      "processing": { "winnow": false }
+    },
+    {
+      "id": "onions",
+      "key": null,
+      "name": "Onions",
+      "category": "garden",
+      "type": "vegetable",
+      "baseDays": 70,
+      "baseYield": 5,
+      "nitrogenUse": -0.05,
+      "glyphs": [".", "`", ",", ";", "o", "O"],
+      "stageSpriteIds": [],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": null,
+        "marketKey": null,
+        "unit": null,
+        "startingQuantity": 0
+      },
+      "seed": {
+        "rate": { "unit": "beds", "value": 1 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "aliases": ["onions"],
+      "processing": { "winnow": false }
+    },
+    {
+      "id": "cabbages",
+      "key": null,
+      "name": "Cabbages",
+      "category": "garden",
+      "type": "vegetable",
+      "baseDays": 75,
+      "baseYield": 6,
+      "nitrogenUse": -0.04,
+      "glyphs": [".", "`", ",", "c", "C", "Q"],
+      "stageSpriteIds": [],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": null,
+        "marketKey": null,
+        "unit": null,
+        "startingQuantity": 0
+      },
+      "seed": {
+        "rate": { "unit": "beds", "value": 1 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "aliases": ["cabbages"],
+      "processing": { "winnow": false }
+    },
+    {
+      "id": "carrots",
+      "key": null,
+      "name": "Carrots",
+      "category": "garden",
+      "type": "root",
+      "baseDays": 65,
+      "baseYield": 5,
+      "nitrogenUse": -0.06,
+      "glyphs": [".", "`", ",", ";", "j", "J"],
+      "stageSpriteIds": [],
+      "rotation": false,
+      "primaryYield": {
+        "storeKey": null,
+        "marketKey": null,
+        "unit": null,
+        "startingQuantity": 0
+      },
+      "seed": {
+        "rate": { "unit": "beds", "value": 1 },
+        "inventoryKey": null,
+        "resourceKey": null,
+        "marketItem": null,
+        "startingQuantity": 0
+      },
+      "aliases": ["carrots"],
+      "processing": { "winnow": false }
+    }
+  ]
+}

--- a/js/config/plants.js
+++ b/js/config/plants.js
@@ -1,0 +1,322 @@
+import plantsJson from '../../data/plants.json' with { type: 'json' };
+
+function deepFreeze(value) {
+  if (Array.isArray(value)) {
+    value.forEach(deepFreeze);
+  } else if (value && typeof value === 'object') {
+    Object.values(value).forEach(deepFreeze);
+  }
+  return Object.freeze(value);
+}
+
+function asString(value, fallback = '') {
+  if (value == null) return fallback;
+  const str = String(value).trim();
+  return str || fallback;
+}
+
+function asNumber(value, fallback = 0) {
+  const num = Number(value);
+  return Number.isFinite(num) ? num : fallback;
+}
+
+function normalizeGlyphs(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((g) => asString(g));
+}
+
+function normalizeStageSpriteIds(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((n) => asNumber(n, 0));
+}
+
+function normalizeSeed(raw) {
+  const seed = raw && typeof raw === 'object' ? raw : {};
+  const rateObj = seed.rate && typeof seed.rate === 'object' ? seed.rate : {};
+  const unit = asString(rateObj.unit, 'bu_per_acre');
+  const value = asNumber(rateObj.value, 0);
+  const inventoryKey = seed.inventoryKey == null ? null : asString(seed.inventoryKey, '') || null;
+  const resourceKey = seed.resourceKey == null ? (inventoryKey ? `seed_${inventoryKey}` : null) : asString(seed.resourceKey, '') || null;
+  const marketItem = seed.marketItem == null ? null : asString(seed.marketItem, '') || null;
+  const startingQuantity = asNumber(seed.startingQuantity, 0);
+  return deepFreeze({
+    rate: deepFreeze({ unit, value }),
+    inventoryKey,
+    resourceKey,
+    marketItem,
+    startingQuantity,
+  });
+}
+
+function normalizePrimaryYield(raw) {
+  const payload = raw && typeof raw === 'object' ? raw : {};
+  const storeKey = payload.storeKey == null ? null : asString(payload.storeKey, '') || null;
+  const marketKey = payload.marketKey == null ? null : asString(payload.marketKey, '') || null;
+  const unit = payload.unit == null ? null : asString(payload.unit, '') || null;
+  const startingQuantity = asNumber(payload.startingQuantity, 0);
+  return deepFreeze({ storeKey, marketKey, unit, startingQuantity });
+}
+
+function normalizeSheaf(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const key = asString(raw.key, '');
+  if (!key) return null;
+  const strawPerBushel = asNumber(raw.strawPerBushel, 0);
+  return deepFreeze({ key, strawPerBushel });
+}
+
+function normalizeSalvage(raw) {
+  if (!raw || typeof raw !== 'object') return null;
+  const storeKey = asString(raw.storeKey, '');
+  if (!storeKey) return null;
+  const multiplier = asNumber(raw.multiplier, 1);
+  return deepFreeze({ storeKey, multiplier });
+}
+
+function normalizeProcessing(raw) {
+  if (!raw || typeof raw !== 'object') return deepFreeze({ winnow: false });
+  return deepFreeze({ winnow: !!raw.winnow });
+}
+
+function normalizeAliases(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.map((alias) => asString(alias)).filter((alias) => alias.length > 0);
+}
+
+function ensureRequiredFields(plant) {
+  if (!plant.id) throw new Error('Plant specification missing id');
+  if (!plant.name) throw new Error(`Plant ${plant.id} missing name`);
+  if (!Number.isFinite(plant.baseDays)) throw new Error(`Plant ${plant.id} missing baseDays`);
+  if (!Number.isFinite(plant.baseYield)) throw new Error(`Plant ${plant.id} missing baseYield`);
+  if (!Number.isFinite(plant.nitrogenUse)) throw new Error(`Plant ${plant.id} missing nitrogenUse`);
+  if (!plant.glyphs.length) throw new Error(`Plant ${plant.id} missing glyphs`);
+}
+
+function normalizePlant(spec) {
+  if (!spec || typeof spec !== 'object') {
+    throw new Error('Invalid plant specification: expected object');
+  }
+  const id = asString(spec.id);
+  const key = spec.key == null ? null : asString(spec.key, '') || null;
+  const name = asString(spec.name, id);
+  const category = asString(spec.category, 'arable');
+  const type = asString(spec.type, 'misc');
+  const baseDays = asNumber(spec.baseDays, 0);
+  const baseYield = asNumber(spec.baseYield, 0);
+  const nitrogenUse = asNumber(spec.nitrogenUse, 0);
+  const glyphs = normalizeGlyphs(spec.glyphs);
+  const stageSpriteIds = normalizeStageSpriteIds(spec.stageSpriteIds);
+  const rotation = !!spec.rotation;
+  const primaryYield = normalizePrimaryYield(spec.primaryYield);
+  const seed = normalizeSeed(spec.seed);
+  const sheaf = normalizeSheaf(spec.sheaf);
+  const salvage = normalizeSalvage(spec.salvage);
+  const aliases = normalizeAliases(spec.aliases);
+  const processing = normalizeProcessing(spec.processing);
+
+  const plant = {
+    id,
+    key,
+    name,
+    category,
+    type,
+    baseDays,
+    baseYield,
+    nitrogenUse,
+    glyphs,
+    stageSpriteIds,
+    rotation,
+    primaryYield,
+    seed,
+    sheaf,
+    salvage,
+    aliases,
+    processing,
+  };
+
+  ensureRequiredFields(plant);
+  return deepFreeze(plant);
+}
+
+const rawPlants = Array.isArray(plantsJson?.plants) ? plantsJson.plants : [];
+const normalizedPlants = rawPlants.map(normalizePlant);
+const plantById = new Map();
+for (const plant of normalizedPlants) {
+  if (plantById.has(plant.id)) {
+    throw new Error(`Duplicate plant id detected: ${plant.id}`);
+  }
+  plantById.set(plant.id, plant);
+}
+
+const arablePlants = normalizedPlants.filter((plant) => plant.category === 'arable');
+const gardenPlants = normalizedPlants.filter((plant) => plant.category === 'garden');
+
+const cropsById = Object.freeze(Object.fromEntries(arablePlants.map((plant) => [plant.id, plant])));
+const cropsByKey = (() => {
+  const entries = new Map();
+  for (const plant of arablePlants) {
+    if (plant.key) {
+      if (entries.has(plant.key)) {
+        throw new Error(`Duplicate plant key detected: ${plant.key}`);
+      }
+      entries.set(plant.key, plant);
+    }
+  }
+  return Object.freeze(Object.fromEntries(entries));
+})();
+
+const rotationIds = Array.isArray(plantsJson?.rotation) ? plantsJson.rotation : [];
+const rotationPlants = rotationIds.map((id) => {
+  const plant = plantById.get(id);
+  if (!plant) throw new Error(`Rotation references unknown plant id: ${id}`);
+  return plant;
+});
+
+const stageSpritesByKey = Object.freeze(Object.fromEntries(
+  arablePlants
+    .filter((plant) => plant.key && plant.stageSpriteIds.length)
+    .map((plant) => [plant.key, plant.stageSpriteIds])
+));
+
+const glyphsByKey = Object.freeze(Object.fromEntries(
+  arablePlants
+    .filter((plant) => plant.key && plant.glyphs.length)
+    .map((plant) => [plant.key, plant.glyphs])
+));
+
+const strawPerBushelById = Object.freeze(Object.fromEntries(
+  arablePlants
+    .filter((plant) => plant.sheaf && Number.isFinite(plant.sheaf.strawPerBushel))
+    .map((plant) => [plant.id, plant.sheaf.strawPerBushel])
+));
+
+const seedRateBuPerAcreById = Object.freeze(Object.fromEntries(
+  normalizedPlants
+    .filter((plant) => plant.seed.rate.unit === 'bu_per_acre')
+    .map((plant) => [plant.id, plant.seed.rate.value])
+));
+
+const seedConfigs = (() => {
+  const entries = [];
+  for (const plant of normalizedPlants) {
+    const { inventoryKey, resourceKey, marketItem, startingQuantity } = plant.seed;
+    if (!inventoryKey && !resourceKey && !marketItem && !plant.seed.rate.value) continue;
+    entries.push({
+      plantId: plant.id,
+      inventoryKey: inventoryKey ?? null,
+      resourceKey: resourceKey ?? null,
+      marketItem: marketItem ?? null,
+      startingQuantity,
+      rate: plant.seed.rate,
+    });
+  }
+  return deepFreeze(entries);
+})();
+
+const seedConfigByPlantId = Object.freeze(Object.fromEntries(seedConfigs.map((config) => [config.plantId, config])));
+const seedConfigByInventoryKey = Object.freeze(Object.fromEntries(
+  seedConfigs
+    .filter((config) => config.inventoryKey)
+    .map((config) => [config.inventoryKey, config])
+));
+const seedConfigByResourceKey = Object.freeze(Object.fromEntries(
+  seedConfigs
+    .filter((config) => config.resourceKey)
+    .map((config) => [config.resourceKey, config])
+));
+const seedConfigByMarketItem = Object.freeze(Object.fromEntries(
+  seedConfigs
+    .filter((config) => config.marketItem)
+    .map((config) => [config.marketItem, config])
+));
+
+const sheafKeyMap = (() => {
+  const map = new Map();
+  for (const plant of arablePlants) {
+    if (plant.sheaf?.key) {
+      const keys = new Set([plant.sheaf.key, plant.id, plant.id?.toUpperCase?.(), plant.key].filter(Boolean));
+      for (const key of keys) {
+        if (map.has(key)) {
+          throw new Error(`Duplicate sheaf key detected: ${key}`);
+        }
+        map.set(key, plant.id);
+      }
+    }
+  }
+  return Object.freeze(Object.fromEntries(map));
+})();
+
+const primaryYieldStoreKeyById = Object.freeze(Object.fromEntries(
+  normalizedPlants
+    .filter((plant) => plant.primaryYield.storeKey)
+    .map((plant) => [plant.id, plant.primaryYield.storeKey])
+));
+
+const primaryYieldMarketKeyById = Object.freeze(Object.fromEntries(
+  normalizedPlants
+    .filter((plant) => plant.primaryYield.marketKey)
+    .map((plant) => [plant.id, plant.primaryYield.marketKey])
+));
+
+const salvageById = Object.freeze(Object.fromEntries(
+  normalizedPlants
+    .filter((plant) => plant.salvage || plant.primaryYield.storeKey)
+    .map((plant) => [plant.id, {
+      storeKey: plant.salvage?.storeKey ?? plant.primaryYield.storeKey ?? null,
+      multiplier: plant.salvage?.multiplier ?? 1,
+    }])
+));
+
+const winnowablePlants = Object.freeze(arablePlants.filter((plant) => plant.processing.winnow));
+
+const aliasToPlantId = Object.freeze(Object.fromEntries(
+  normalizedPlants
+    .flatMap((plant) => plant.aliases.map((alias) => [alias, plant.id]))
+));
+
+export const PLANTS = deepFreeze([...normalizedPlants]);
+export const PLANTS_BY_ID = plantById;
+export const CROPS = cropsById;
+export const CROPS_BY_KEY = cropsByKey;
+export const ROTATION = Object.freeze([...rotationPlants]);
+export const ROTATION_IDS = Object.freeze(rotationPlants.map((plant) => plant.id));
+export const STAGE_SIDS_BY_KEY = stageSpritesByKey;
+export const CROP_GLYPHS_BY_KEY = glyphsByKey;
+export const STRAW_PER_BUSHEL_BY_ID = strawPerBushelById;
+export const SEED_RATE_BU_PER_ACRE_BY_ID = seedRateBuPerAcreById;
+export const SEED_CONFIGS = seedConfigs;
+export const SEED_CONFIG_BY_PLANT_ID = seedConfigByPlantId;
+export const SEED_CONFIG_BY_INVENTORY_KEY = seedConfigByInventoryKey;
+export const SEED_CONFIG_BY_RESOURCE_KEY = seedConfigByResourceKey;
+export const SEED_CONFIG_BY_MARKET_ITEM = seedConfigByMarketItem;
+export const SHEAF_KEY_TO_PLANT_ID = sheafKeyMap;
+export const PRIMARY_YIELD_STORE_KEY_BY_ID = primaryYieldStoreKeyById;
+export const PRIMARY_YIELD_MARKET_KEY_BY_ID = primaryYieldMarketKeyById;
+export const SALVAGE_INFO_BY_ID = salvageById;
+export const WINNOWABLE_PLANTS = winnowablePlants;
+export const GARDEN_PLANTS = Object.freeze([...gardenPlants]);
+export const ARABLE_PLANTS = Object.freeze([...arablePlants]);
+export const ALIAS_TO_PLANT_ID = aliasToPlantId;
+
+export function getPlantById(id) {
+  return plantById.get(id) ?? null;
+}
+
+export function getPlantByKey(key) {
+  if (!key) return null;
+  return cropsByKey[key] ?? plantById.get(key) ?? null;
+}
+
+export function getPlantForSheafKey(key) {
+  if (!key) return null;
+  const str = typeof key === 'string' ? key : String(key);
+  const plantId = sheafKeyMap[str] ?? sheafKeyMap[str.toUpperCase()];
+  return plantId ? plantById.get(plantId) ?? null : null;
+}
+
+export function getPlantByAlias(alias) {
+  if (!alias) return null;
+  const str = typeof alias === 'string' ? alias : String(alias);
+  const id = aliasToPlantId[str] ?? aliasToPlantId[str.toLowerCase()];
+  return id ? plantById.get(id) ?? null : null;
+}

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,6 +1,14 @@
 import { DAYS_PER_MONTH as TIME_DAYS_PER_MONTH, MONTHS_PER_YEAR as TIME_MONTHS_PER_YEAR, MINUTES_PER_DAY as TIME_MINUTES_PER_DAY, DAYLIGHT } from './time.js';
 import { CONFIG_PACK_V1 } from './config/pack_v1.js';
 import { INITIAL_LIVESTOCK_COUNTS, PASTURE_INFO_BY_ID } from './config/animals.js';
+import {
+  CROPS as CROPS_FROM_DATA,
+  ROTATION as ROTATION_FROM_DATA,
+  STAGE_SIDS_BY_KEY,
+  CROP_GLYPHS_BY_KEY,
+  STRAW_PER_BUSHEL_BY_ID,
+  SEED_RATE_BU_PER_ACRE_BY_ID,
+} from './config/plants.js';
 
 const PACK = CONFIG_PACK_V1;
 
@@ -75,7 +83,7 @@ export const PLOUGH_TILTH_DELTA = +0.35;
 export const HARROW_TILTH_DELTA = +0.20;
 export const THRESH_LOSS = 0.02;
 
-export const STRAW_PER_BUSHEL = { WHEAT:1.2, BARLEY:1.0, OATS:1.1, PULSES:0.6 };
+export const STRAW_PER_BUSHEL = STRAW_PER_BUSHEL_BY_ID;
 export const OPT_MOIST = 0.60;
 
 export const PASTURE = {
@@ -126,9 +134,9 @@ export const PRICES = {
 
 export const DEMAND = {
   household_wheat_bu_per_day: 0.25,
-  seed_bu_per_acre: {
-    WHEAT:2.0, BARLEY:2.0, OATS:2.0, PULSES:1.5, FLAX:0.0, TURNIPS:0.2
-  }
+  seed_bu_per_acre: Object.freeze({
+    ...SEED_RATE_BU_PER_ACRE_BY_ID,
+  }),
 };
 
 export function seedNeededForParcel(p, cropKey) {
@@ -205,25 +213,9 @@ export const SID = {
   MIXED_LABEL: 200,
 };
 
-export const SID_BY_CROP = {
-  T: [SID.SOIL_TILLED, SID.T_S1, SID.T_S2, SID.T_S3, SID.T_S4, SID.T_S5],
-  B: [SID.SOIL_TILLED, SID.B_S1, SID.B_S2, SID.B_S3, SID.B_S4, SID.B_S5],
-  C: [SID.SOIL_TILLED, SID.C_S1, SID.C_S2, SID.C_S3, SID.C_S4, SID.C_S5],
-  W: [SID.SOIL_TILLED, SID.W_S1, SID.W_S2, SID.W_S3, SID.W_S4, SID.W_S5],
-  O: [SID.SOIL_TILLED, SID.O_S1, SID.O_S2, SID.O_S3, SID.O_S4, SID.O_S5],
-  P: [SID.SOIL_TILLED, SID.P_S1, SID.P_S2, SID.P_S3, SID.P_S4, SID.P_S5],
-  F: [SID.SOIL_TILLED, SID.F_S1, SID.F_S2, SID.F_S3, SID.F_S4, SID.F_S5],
-};
+export const SID_BY_CROP = STAGE_SIDS_BY_KEY;
 
-export const CROP_GLYPHS = {
-  T: ['.', '`', ',', 'v', 'w', 'W'],
-  B: ['.', ',', ';', 't', 'Y', 'H'],
-  C: ['.', ',', '"', '*', 'c', 'C'],
-  W: ['.', ',', ';', 'i', 'I', 'W'],
-  O: ['.', ',', ';', 't', 'T', 'Y'],
-  P: ['.', 'o', 'd', 'b', '8', '&'],
-  F: ['.', '|', 'i', 't', 'T', '#'],
-};
+export const CROP_GLYPHS = CROP_GLYPHS_BY_KEY;
 
 export const GRASS_GLYPHS = {
   [SID.GRASS_DRY]: '.',
@@ -232,16 +224,8 @@ export const GRASS_GLYPHS = {
   [SID.GRASS_VERY_LUSH]: '"',
 };
 
-export const CROPS = {
-  TURNIPS: { key:'T', name:'Turnips', type:'root', baseDays: 80, baseYield: 60, nUse: -0.10 },
-  BARLEY:  { key:'B', name:'Barley',  type:'grain', baseDays: 85, baseYield: 70, nUse: -0.12 },
-  CLOVER:  { key:'C', name:'Clover',  type:'legume', baseDays: 70, baseYield: 25, nUse: +0.18 },
-  WHEAT:   { key:'W', name:'Wheat',   type:'grain', baseDays: 95, baseYield: 80, nUse: -0.14 },
-  OATS:    { key:'O', name:'Oats',    type:'grain', baseDays: 85, baseYield: 65, nUse: -0.12 },
-  PULSES:  { key:'P', name:'Beans/Peas/Vetch', type:'pulse', baseDays:90, baseYield:45, nUse:+0.06 },
-  FLAX:    { key:'F', name:'Flax/Hemp', type:'fiber', baseDays:100, baseYield:30, nUse:-0.10 },
-};
+export const CROPS = CROPS_FROM_DATA;
 
-export const ROTATION = [CROPS.TURNIPS, CROPS.BARLEY, CROPS.CLOVER, CROPS.WHEAT];
+export const ROTATION = ROTATION_FROM_DATA;
 
 export const LIVESTOCK_START = Object.freeze({ ...INITIAL_LIVESTOCK_COUNTS });

--- a/js/resources.js
+++ b/js/resources.js
@@ -1,9 +1,15 @@
+import { SEED_CONFIGS } from './config/plants.js';
+
+const seedResourceEntries = Object.fromEntries(
+  SEED_CONFIGS
+    .filter((config) => config.resourceKey && config.inventoryKey)
+    .map((config) => [config.resourceKey, { path: ['store', 'seed', config.inventoryKey] }])
+);
+
 const RESOURCE_MAP = Object.freeze({
   cash: { path: ['cash'] },
   turnips: { path: ['store', 'turnips'] },
-  seed_barley: { path: ['store', 'seed', 'barley'] },
-  seed_oats: { path: ['store', 'seed', 'oats'] },
-  seed_pulses: { path: ['store', 'seed', 'pulses'] },
+  ...seedResourceEntries,
 });
 
 function resolveContainer(root, path, create = false) {

--- a/js/tests/plants.test.js
+++ b/js/tests/plants.test.js
@@ -1,0 +1,72 @@
+import { strict as assert } from 'node:assert';
+import {
+  PLANTS,
+  ARABLE_PLANTS,
+  GARDEN_PLANTS,
+  ROTATION,
+  STAGE_SIDS_BY_KEY,
+  CROP_GLYPHS_BY_KEY,
+  STRAW_PER_BUSHEL_BY_ID,
+  SEED_CONFIGS,
+  getPlantForSheafKey,
+} from '../config/plants.js';
+
+export function testPlantSchema() {
+  assert.ok(Array.isArray(PLANTS) && PLANTS.length > 0, 'plants collection must be non-empty');
+  for (const plant of PLANTS) {
+    assert.ok(plant.id && typeof plant.id === 'string', 'plant id must be string');
+    assert.ok(plant.name && typeof plant.name === 'string', 'plant name must be string');
+    assert.ok(Number.isFinite(plant.baseDays), `plant ${plant.id} missing baseDays`);
+    assert.ok(Number.isFinite(plant.baseYield), `plant ${plant.id} missing baseYield`);
+    assert.ok(Number.isFinite(plant.nitrogenUse), `plant ${plant.id} missing nitrogenUse`);
+    assert.ok(Array.isArray(plant.glyphs) && plant.glyphs.length > 0, `plant ${plant.id} missing glyphs`);
+    assert.ok(plant.primaryYield && typeof plant.primaryYield === 'object', `plant ${plant.id} missing primary yield`);
+    if (plant.sheaf?.key) {
+      assert.strictEqual(getPlantForSheafKey(plant.sheaf.key)?.id, plant.id, `sheaf key must resolve for ${plant.id}`);
+    }
+  }
+}
+
+export function testRotationPlants() {
+  assert.ok(Array.isArray(ROTATION) && ROTATION.length > 0, 'rotation must include plants');
+  for (const plant of ROTATION) {
+    assert.ok(plant && typeof plant.id === 'string', 'rotation entries must be valid plants');
+  }
+}
+
+export function testArableRenderAssets() {
+  for (const plant of ARABLE_PLANTS) {
+    if (plant.key) {
+      const sprites = STAGE_SIDS_BY_KEY[plant.key];
+      const glyphs = CROP_GLYPHS_BY_KEY[plant.key];
+      assert.ok(Array.isArray(sprites) && sprites.length > 0, `sprites missing for ${plant.key}`);
+      assert.ok(Array.isArray(glyphs) && glyphs.length > 0, `glyphs missing for ${plant.key}`);
+    }
+  }
+}
+
+export function testSeedAndStrawMaps() {
+  for (const config of SEED_CONFIGS) {
+    if (config.inventoryKey) {
+      assert.ok(typeof config.resourceKey === 'string' && config.resourceKey.length > 0, 'seed resource key required');
+    }
+    if (config.marketItem) {
+      assert.ok(config.marketItem.startsWith('seed_'), 'seed market item should use seed_ prefix');
+    }
+  }
+  for (const plant of ARABLE_PLANTS) {
+    if (plant.sheaf?.key) {
+      assert.ok(Number.isFinite(STRAW_PER_BUSHEL_BY_ID[plant.id]), `straw data missing for ${plant.id}`);
+    }
+  }
+}
+
+export function testGardenPlantsPresent() {
+  assert.ok(Array.isArray(GARDEN_PLANTS));
+  const ids = new Set();
+  for (const plant of GARDEN_PLANTS) {
+    assert.ok(plant.id && typeof plant.id === 'string', 'garden plant must have id');
+    assert.ok(!ids.has(plant.id), 'garden plant ids must be unique');
+    ids.add(plant.id);
+  }
+}

--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -9,6 +9,13 @@ import {
 import { testSeasonOfMonthAcceptsRomanNumerals } from './constants.test.js';
 import { testDailyTurnMonthRollover } from './simulation-date.test.js';
 import { testAnimalSchema, testAnimalIntegration } from './animals.test.js';
+import {
+  testPlantSchema,
+  testRotationPlants,
+  testArableRenderAssets,
+  testSeedAndStrawMaps,
+  testGardenPlantsPresent,
+} from './plants.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -22,6 +29,11 @@ const tests = [
   ['season helper accepts roman numerals', testSeasonOfMonthAcceptsRomanNumerals],
   ['animal data schema validated', testAnimalSchema],
   ['animal data drives simulation', testAnimalIntegration],
+  ['plant data schema validated', testPlantSchema],
+  ['rotation plants resolvable', testRotationPlants],
+  ['arable plants provide render assets', testArableRenderAssets],
+  ['seed and straw helpers consistent', testSeedAndStrawMaps],
+  ['garden plants enumerated', testGardenPlantsPresent],
 ];
 
 let failed = false;


### PR DESCRIPTION
## Summary
- move crop and garden metadata into data/plants.json and add a loader for typed plant access
- refactor simulation, advisor, jobs, markets, and rendering helpers to consume JSON-backed plant data
- update resource mappings and add schema validation tests for the new plant configuration

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de0e49907c832baea8ddb7efcd3848