### PR TITLE
Add pulses and flax to six-course rotation

### DIFF
--- a/data/plants.json
+++ b/data/plants.json
@@ -1,5 +1,5 @@
 {
-  "rotation": ["TURNIPS", "BARLEY", "CLOVER", "WHEAT"],
+  "rotation": ["TURNIPS", "BARLEY", "CLOVER", "WHEAT", "PULSES", "FLAX"],
   "plants": [
     {
       "id": "TURNIPS",
@@ -156,7 +156,7 @@
       "nitrogenUse": 0.06,
       "glyphs": [".", "o", "d", "b", "8", "&"],
       "stageSpriteIds": [11, 70, 71, 72, 73, 74],
-      "rotation": false,
+      "rotation": true,
       "primaryYield": {
         "storeKey": "pulses",
         "marketKey": "pulses_bu",
@@ -185,7 +185,7 @@
       "nitrogenUse": -0.1,
       "glyphs": [".", "|", "i", "t", "T", "#"],
       "stageSpriteIds": [11, 80, 81, 82, 83, 84],
-      "rotation": false,
+      "rotation": true,
       "primaryYield": {
         "storeKey": "flax",
         "marketKey": null,


### PR DESCRIPTION
## Summary
- extend the rotation configuration to include pulses and flax so all six phases are represented
- mark the pulses and flax crops as rotation participants so they appear in the rotation build

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de16a1e9a4832b9a12f620868e6190