### PR TITLE
Guard menu toggle handler when drawer is missing

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -133,11 +133,14 @@ function selectDom() {
 function initEvents() {
   if (DOM.menuToggle) {
     DOM.menuToggle.addEventListener('click', () => {
-      const hidden = DOM.drawer.hasAttribute('hidden');
+      const drawer = DOM.drawer;
+      if (!drawer) return;
+
+      const hidden = drawer.hasAttribute('hidden');
       if (hidden) {
-        DOM.drawer.removeAttribute('hidden');
+        drawer.removeAttribute('hidden');
       } else {
-        DOM.drawer.setAttribute('hidden', '');
+        drawer.setAttribute('hidden', '');
       }
       DOM.menuToggle.setAttribute('aria-expanded', hidden ? 'true' : 'false');
     });
@@ -581,5 +584,7 @@ function boot() {
     clock.start();
   }
 }
+
+export { initEvents, DOM };
 
 document.addEventListener('DOMContentLoaded', boot);

--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -16,6 +16,7 @@ import {
   testSeedAndStrawMaps,
   testGardenPlantsPresent,
 } from './plants.test.js';
+import { testMenuToggleHandlesMissingDrawer } from './ui-menu.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -34,6 +35,7 @@ const tests = [
   ['arable plants provide render assets', testArableRenderAssets],
   ['seed and straw helpers consistent', testSeedAndStrawMaps],
   ['garden plants enumerated', testGardenPlantsPresent],
+  ['menu toggle tolerates missing drawer', testMenuToggleHandlesMissingDrawer],
 ];
 
 let failed = false;

--- a/js/tests/ui-menu.test.js
+++ b/js/tests/ui-menu.test.js
@@ -1,0 +1,54 @@
+const originalDocument = globalThis.document;
+
+function restoreDocument() {
+  if (originalDocument === undefined) {
+    delete globalThis.document;
+  } else {
+    globalThis.document = originalDocument;
+  }
+}
+
+export async function testMenuToggleHandlesMissingDrawer() {
+  globalThis.document = {
+    addEventListener: () => {},
+  };
+
+  try {
+    const module = await import('../main.js');
+    const { initEvents, DOM } = module;
+
+    const originalDrawer = DOM.drawer;
+    const originalMenuToggle = DOM.menuToggle;
+
+    let clickHandler;
+    const setAttributeCalls = [];
+    DOM.menuToggle = {
+      addEventListener: (type, handler) => {
+        if (type === 'click') {
+          clickHandler = handler;
+        }
+      },
+      setAttribute: (name, value) => {
+        setAttributeCalls.push([name, value]);
+      },
+    };
+    DOM.drawer = null;
+
+    initEvents();
+
+    if (typeof clickHandler !== 'function') {
+      throw new Error('Menu toggle click handler was not registered');
+    }
+
+    clickHandler();
+
+    if (setAttributeCalls.length !== 0) {
+      throw new Error('aria-expanded was updated despite missing drawer');
+    }
+
+    DOM.menuToggle = originalMenuToggle;
+    DOM.drawer = originalDrawer;
+  } finally {
+    restoreDocument();
+  }
+}


### PR DESCRIPTION
## Summary
- guard the menu toggle click handler so it exits when the drawer reference is missing while keeping the aria-expanded update when available
- export the menu helpers used by the test harness
- add a regression test covering the menu toggle without an info drawer and wire it into the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e0786ddb50832bac43d44525145d8b