### PR TITLE
Handle wraparound windows in scheduler

### DIFF
--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -165,7 +165,10 @@ export function jobsInWindow(monthLabel) {
     const start = monthIndexFromLabel(job.window?.[0] ?? monthLabel);
     const end = monthIndexFromLabel(job.window?.[1] ?? monthLabel);
     const idx = monthIndexFromLabel(monthLabel);
-    return idx >= start && idx <= end;
+    if (start <= end) {
+      return idx >= start && idx <= end;
+    }
+    return idx >= start || idx <= end;
   });
 }
 

--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -17,6 +17,10 @@ import {
   testGardenPlantsPresent,
 } from './plants.test.js';
 import { testMenuToggleHandlesMissingDrawer } from './ui-menu.test.js';
+import {
+  testJobsInWindowHandlesWraparound,
+  testJobsInWindowSingleMonthInvariant,
+} from './scheduler.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -36,6 +40,8 @@ const tests = [
   ['seed and straw helpers consistent', testSeedAndStrawMaps],
   ['garden plants enumerated', testGardenPlantsPresent],
   ['menu toggle tolerates missing drawer', testMenuToggleHandlesMissingDrawer],
+  ['jobs window handles wraparound', testJobsInWindowHandlesWraparound],
+  ['jobs window single month invariant', testJobsInWindowSingleMonthInvariant],
 ];
 
 let failed = false;

--- a/js/tests/scheduler.test.js
+++ b/js/tests/scheduler.test.js
@@ -1,0 +1,37 @@
+import { strict as assert } from 'node:assert';
+import { jobsInWindow } from '../scheduler.js';
+import { JOBS } from '../jobs.js';
+
+export function testJobsInWindowHandlesWraparound() {
+  const wrapJob = {
+    id: 'wrap_test_job',
+    window: ['VIII', 'II'],
+  };
+
+  JOBS.push(wrapJob);
+  try {
+    const includedMonths = ['VIII', 'I', 'II'];
+    for (const month of includedMonths) {
+      const jobs = jobsInWindow(month);
+      assert.ok(jobs.some((job) => job.id === wrapJob.id), `${wrapJob.id} should be in window for ${month}`);
+    }
+
+    const excludedMonths = ['III', 'IV'];
+    for (const month of excludedMonths) {
+      const jobs = jobsInWindow(month);
+      assert.ok(!jobs.some((job) => job.id === wrapJob.id), `${wrapJob.id} should not be in window for ${month}`);
+    }
+  } finally {
+    JOBS.pop();
+  }
+}
+
+export function testJobsInWindowSingleMonthInvariant() {
+  const targetJobId = 'plough_barley';
+
+  const januaryJobs = jobsInWindow('I');
+  assert.ok(januaryJobs.some((job) => job.id === targetJobId), `${targetJobId} should be scheduled in I`);
+
+  const februaryJobs = jobsInWindow('II');
+  assert.ok(!februaryJobs.some((job) => job.id === targetJobId), `${targetJobId} should only be scheduled in I`);
+}


### PR DESCRIPTION
## Summary
- allow the scheduler to treat month windows with later starts than ends as wrapping across the calendar
- add scheduler unit coverage to verify wraparound handling and preserve single-month behavior
- register the new scheduler tests in the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e079273358832b8d363dc8aaae1850