### PR TITLE
Normalize calendar month stamp

### DIFF
--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -7,7 +7,7 @@ import {
   testOneBasedMonthIndex,
 } from './simulation-clock.test.js';
 import { testSeasonOfMonthAcceptsRomanNumerals } from './constants.test.js';
-import { testDailyTurnMonthRollover } from './simulation-date.test.js';
+import { testDailyTurnMonthRollover, testStampNormalizesRomanMonth } from './simulation-date.test.js';
 import { testAnimalSchema, testAnimalIntegration } from './animals.test.js';
 import {
   testPlantSchema,
@@ -30,6 +30,7 @@ const tests = [
   ['world farmer mirrors engine state', testWorldFarmerStateSync],
   ['month rollover boundaries', testMonthRolloverBoundaries],
   ['daily turn month rollover preserves labels', testDailyTurnMonthRollover],
+  ['stamp normalizes roman numeral months', testStampNormalizesRomanMonth],
   ['one-based month index preserves first month', testOneBasedMonthIndex],
   ['season helper accepts roman numerals', testSeasonOfMonthAcceptsRomanNumerals],
   ['animal data schema validated', testAnimalSchema],

--- a/js/tests/simulation-date.test.js
+++ b/js/tests/simulation-date.test.js
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 
-import { createInitialWorld } from '../world.js';
+import { createInitialWorld, stamp } from '../world.js';
 import { dailyTurn } from '../simulation.js';
 import { DAYS_PER_MONTH, MONTH_NAMES } from '../constants.js';
 
@@ -20,4 +20,15 @@ export function testDailyTurnMonthRollover() {
   assert.equal(world.calendar.month, MONTH_NAMES[0], 'month label should match wrapped index');
   assert.equal(world.calendar.year, 4, 'year should increment when month wraps');
   assert.equal(world.daylight.month, MONTH_NAMES[0], 'daylight schedule should align with month label');
+}
+
+export function testStampNormalizesRomanMonth() {
+  const world = createInitialWorld();
+
+  world.calendar.month = 'IV';
+  world.calendar.monthIndex = 3;
+
+  const stamped = stamp(world);
+
+  assert.equal(stamped.m, 4, 'stamp should normalize roman numeral month to one-based index');
 }

--- a/js/world.js
+++ b/js/world.js
@@ -95,6 +95,21 @@ const STORE_SHEAVES_TEMPLATE = freezeDeep(Object.fromEntries(
 
 const DEFAULT_SOIL = Object.freeze({ moisture: 0.55, nitrogen: 0.6 });
 
+const ROMAN_MONTH_TO_NUMBER = Object.freeze({
+  I: 1,
+  II: 2,
+  III: 3,
+  IV: 4,
+  V: 5,
+  VI: 6,
+  VII: 7,
+  VIII: 8,
+  IX: 9,
+  X: 10,
+  XI: 11,
+  XII: 12,
+});
+
 const PACK_FARMHOUSE = DEFAULT_PACK_V1?.estate?.farmhouse;
 const DEFAULT_FARMHOUSE_CENTER = {
   x: HOUSE.x + Math.floor(HOUSE.w / 2),
@@ -523,7 +538,20 @@ export function attachPastureIfNeeded(parcel) {
 export function stamp(world) {
   const cal = world?.calendar || {};
   const year = Number.isFinite(cal.year) ? cal.year : 1;
-  const month = Number.isFinite(cal.month) ? cal.month : 1;
+  let month;
+  if (Number.isFinite(cal.monthIndex)) {
+    month = cal.monthIndex + 1;
+  } else if (Number.isFinite(cal.month)) {
+    month = cal.month;
+  } else if (typeof cal.month === 'string') {
+    const normalized = cal.month.trim().toUpperCase();
+    month = ROMAN_MONTH_TO_NUMBER[normalized];
+    if (!Number.isFinite(month)) {
+      const parsed = Number.parseInt(normalized, 10);
+      if (Number.isFinite(parsed)) month = parsed;
+    }
+  }
+  if (!Number.isFinite(month)) month = 1;
   const day = Number.isFinite(cal.day) ? cal.day : 1;
   return { y: year, m: month, d: day };
 }


### PR DESCRIPTION
## Summary
- normalize the calendar stamping helper to derive month numbers from either zero-based indices or roman numeral strings
- extend the simulation date test suite to cover roman month normalization
- register the new test with the test runner

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e07bacbb1c832bad2fb01357ea9800