### PR TITLE
Handle wrap-around windows in scheduling

### DIFF
--- a/js/scheduler.js
+++ b/js/scheduler.js
@@ -19,6 +19,21 @@ function compareMonths(a, b) {
   return monthIndexFromLabel(a) - monthIndexFromLabel(b);
 }
 
+export function monthInWindow(monthIdx, startIdx, endIdx) {
+  if (!Number.isFinite(monthIdx) || !Number.isFinite(startIdx) || !Number.isFinite(endIdx)) {
+    return false;
+  }
+  const totalMonths = CALENDAR.MONTHS.length;
+  const wraps = startIdx > endIdx;
+  const normalizedStart = startIdx;
+  const normalizedEnd = wraps ? endIdx + totalMonths : endIdx;
+  let normalizedMonth = monthIdx;
+  if (wraps && normalizedMonth < startIdx) {
+    normalizedMonth += totalMonths;
+  }
+  return normalizedMonth >= normalizedStart && normalizedMonth <= normalizedEnd;
+}
+
 export function inWindow(state, window) {
   if (!state?.world?.calendar) return false;
   if (!Array.isArray(window) || window.length < 2) return true;
@@ -26,7 +41,7 @@ export function inWindow(state, window) {
   const idx = monthIndexFromLabel(month);
   const start = monthIndexFromLabel(window[0]);
   const end = monthIndexFromLabel(window[1]);
-  return idx >= start && idx <= end;
+  return monthInWindow(idx, start, end);
 }
 
 export function prerequisitesMet(state, job) {
@@ -165,10 +180,7 @@ export function jobsInWindow(monthLabel) {
     const start = monthIndexFromLabel(job.window?.[0] ?? monthLabel);
     const end = monthIndexFromLabel(job.window?.[1] ?? monthLabel);
     const idx = monthIndexFromLabel(monthLabel);
-    if (start <= end) {
-      return idx >= start && idx <= end;
-    }
-    return idx >= start || idx <= end;
+    return monthInWindow(idx, start, end);
   });
 }
 

--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -20,7 +20,9 @@ import { testMenuToggleHandlesMissingDrawer } from './ui-menu.test.js';
 import {
   testJobsInWindowHandlesWraparound,
   testJobsInWindowSingleMonthInvariant,
+  testIsEligibleHonorsWrappedWindow,
 } from './scheduler.test.js';
+import { testWrappedJobStatusQueuedAndOverdue } from './main.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -43,6 +45,8 @@ const tests = [
   ['menu toggle tolerates missing drawer', testMenuToggleHandlesMissingDrawer],
   ['jobs window handles wraparound', testJobsInWindowHandlesWraparound],
   ['jobs window single month invariant', testJobsInWindowSingleMonthInvariant],
+  ['isEligible respects wrapped windows', testIsEligibleHonorsWrappedWindow],
+  ['status queued/overdue for wrapped window', testWrappedJobStatusQueuedAndOverdue],
 ];
 
 let failed = false;


### PR DESCRIPTION
## Summary
- add a reusable helper for wrap-aware month window checks and use it for eligibility and listings
- update job status calculations to respect wrap-around windows and allow injection of test state
- extend scheduler tests and add a main test to cover wrap-around eligibility/status scenarios

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e12b4dddb4832b869afc43c7a1607a