### PR TITLE
Handle skipped jobs when instantiation fails

### DIFF
--- a/js/engine.js
+++ b/js/engine.js
@@ -205,9 +205,18 @@ function beginScheduledTask(state) {
       state.currentTask = null;
       return null;
     }
-    const runtime = instantiateJob(state.world, next);
+    let instantiationDetails = null;
+    const runtime = instantiateJob(state.world, next, {
+      onBlocked: (details = {}) => {
+        instantiationDetails = { ...details };
+      },
+    });
     if (!runtime) {
-      recordTaskHistory(state, next);
+      const reason = instantiationDetails?.reason;
+      noteTaskBlocked(state, next, null, {
+        ...instantiationDetails,
+        reason: typeof reason === 'string' && reason.length ? reason : undefined,
+      });
       continue;
     }
     if (typeof runtime.canApply === 'function') {

--- a/js/main.js
+++ b/js/main.js
@@ -188,6 +188,9 @@ export function computeJobStatus(job, { state: targetState = state } = {}) {
   const inCurrentWindow = monthInWindow(monthIdx, startIdx, endIdx);
   const doneSet = engine?.progress?.done instanceof Set ? engine.progress.done : new Set();
   if (doneSet.has(job.id)) return 'completed';
+  if (engine?.taskSkips instanceof Map && engine.taskSkips.has(job.id)) {
+    return 'skipped';
+  }
   if (normalizedMonth > normalizedEnd) return 'overdue';
   if (!engine) return 'planned';
   if (!wraps && monthIdx < startIdx) return 'planned';

--- a/js/tests/run.js
+++ b/js/tests/run.js
@@ -22,8 +22,8 @@ import {
   testJobsInWindowSingleMonthInvariant,
   testIsEligibleHonorsWrappedWindow,
 } from './scheduler.test.js';
-import { testWrappedJobStatusQueuedAndOverdue } from './main.test.js';
-import { testMarketTripRetryAfterCanApplyFailure } from './engine.test.js';
+import { testWrappedJobStatusQueuedAndOverdue, testSkippedJobStatusReported } from './main.test.js';
+import { testMarketTripRetryAfterCanApplyFailure, testFieldWorkReschedulesAfterParcelAppears } from './engine.test.js';
 
 const tests = [
   ['config close field within steps', assertCloseFieldWithinSteps],
@@ -48,7 +48,9 @@ const tests = [
   ['jobs window single month invariant', testJobsInWindowSingleMonthInvariant],
   ['isEligible respects wrapped windows', testIsEligibleHonorsWrappedWindow],
   ['status queued/overdue for wrapped window', testWrappedJobStatusQueuedAndOverdue],
+  ['skipped job status reported', testSkippedJobStatusReported],
   ['market trip retries after canApply failure', testMarketTripRetryAfterCanApplyFailure],
+  ['field work reschedules after parcel appears', testFieldWorkReschedulesAfterParcelAppears],
 ];
 
 let failed = false;


### PR DESCRIPTION
## Summary
- mark jobs as skipped when instantiation fails and capture the skip reason instead of recording completion
- surface skipped task state through computeJobStatus for planners and logs
- add regression coverage for skipped statuses and field jobs blocked by missing parcels

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e38f94bea4832ba3de729ae8cf5376