### PR TITLE
Add toast animations to notifications

### DIFF
--- a/style.css
+++ b/style.css
@@ -201,13 +201,92 @@ button:focus-visible {
   display: none;
 }
 
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateY(12px) scale(0.96);
+    filter: blur(2px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+}
+
+@keyframes toast-out {
+  from {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+    filter: blur(0);
+  }
+
+  to {
+    opacity: 0;
+    transform: translateY(-6px) scale(0.94);
+    filter: blur(2px);
+  }
+}
+
+@keyframes toast-life {
+  from {
+    width: calc(100% - 20px);
+  }
+
+  to {
+    width: 0;
+  }
+}
+
 .message {
+  position: relative;
   background: var(--message-bg);
   color: var(--fg);
   padding: 8px 12px;
-  border-radius: 8px;
+  border-radius: 10px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
   border-left: 3px solid var(--accent);
-  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.35);
+  box-shadow: 0 16px 36px rgba(0, 0, 0, 0.42);
+  transform-origin: top left;
+  animation: toast-in 220ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+.message[data-state="closing"],
+.message[data-state="exit"],
+.message.is-leaving {
+  animation: toast-out 180ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+}
+
+.message::after {
+  content: "";
+  position: absolute;
+  left: 10px;
+  bottom: 6px;
+  height: 3px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 75%, transparent);
+  width: calc(100% - 20px);
+  max-width: calc(100% - 20px);
+  min-width: 0;
+  animation: toast-life 4800ms linear forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .message {
+    animation: none;
+  }
+
+  .message[data-state="closing"],
+  .message[data-state="exit"],
+  .message.is-leaving {
+    animation: none;
+  }
+
+  .message::after {
+    animation: none;
+    width: calc(100% - 20px);
+  }
 }
 
 #speed-controls {


### PR DESCRIPTION
## Summary
- add keyframe animations for toast entry, exit, and lifetime progress
- animate message containers with updated styling and a progress indicator, respecting reduced motion settings

## Testing
- Not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68e57d4420b0832b9723b50dfa84c0ee