### PR TITLE
Enhance menu tab interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -355,12 +355,39 @@ button:focus-visible {
 .menu-item {
   flex: 1 1 45%;
   text-align: center;
+  position: relative;
+  transition: color 160ms ease, transform 160ms ease, box-shadow 200ms ease;
+}
+
+.menu-item::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  bottom: 6px;
+  width: 70%;
+  height: 2px;
+  border-radius: 999px;
+  background: var(--accent);
+  opacity: 0;
+  transform: translateX(-50%) scaleX(0.45);
+  transform-origin: center;
+  transition: opacity 160ms ease, transform 180ms ease;
+  pointer-events: none;
+}
+
+.menu-item:hover::after,
+.menu-item:focus-visible::after,
+.menu-item.active::after {
+  opacity: 1;
+  transform: translateX(-50%) scaleX(1);
 }
 
 .menu-item.active {
   background: var(--accent);
   color: #0b0e12;
   border-color: var(--accent);
+  transform: translateY(1px);
+  box-shadow: inset 0 2px 4px rgba(11, 14, 18, 0.25);
 }
 
 #panel-content {


### PR DESCRIPTION
## Summary
- make menu buttons position-aware and transition their color/transform for smoother feedback
- add an accent bar pseudo-element that animates on hover, focus, and active states
- give the active menu tab a pressed appearance without losing focus visibility

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e57e5f92bc832b88b48e874ba1b657